### PR TITLE
Solved getSubscriptionById() RestAPI not responding with empy JSON, responded with empty string before this fix, when no Subscription was found, which caused errors in webBrowser using EI Frontend.

### DIFF
--- a/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
@@ -51,7 +51,7 @@ public interface SubscriptionController {
      * 
      */
     @RequestMapping(value = "/{subscriptionName}", method = RequestMethod.GET)
-    public ResponseEntity<com.ericsson.ei.controller.model.Subscription> getSubscriptionById(
+    public ResponseEntity<List<com.ericsson.ei.controller.model.Subscription>> getSubscriptionById(
         @PathVariable
         String subscriptionName);
 

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -39,6 +39,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
     
     private static final Logger LOG = LoggerFactory.getLogger(SubscriptionControllerImpl.class);
     
+    
     @Override
     @CrossOrigin
     @ApiOperation(value = "Creates the subscription")
@@ -51,7 +52,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             return new ResponseEntity<SubscriptionResponse>(subscriptionResponse, HttpStatus.OK);
         } else {
             LOG.error("Subscription :" + subscription.getSubscriptionName() + " identified as duplicate subscription");
-            subscriptionResponse.setMsg("Duplicate Subscription"); subscriptionResponse.setStatusCode(HttpStatus.BAD_REQUEST.value());
+            subscriptionResponse.setMsg("Subscription already exists"); subscriptionResponse.setStatusCode(HttpStatus.BAD_REQUEST.value());
             return new ResponseEntity<SubscriptionResponse>(subscriptionResponse, HttpStatus.BAD_REQUEST);
         }
         
@@ -60,16 +61,17 @@ public class SubscriptionControllerImpl implements SubscriptionController {
     @Override
     @CrossOrigin
     @ApiOperation(value = "Returns the subscription rules for given subscription name")
-    public ResponseEntity<Subscription> getSubscriptionById(@PathVariable String subscriptionName) {
-        Subscription subscription = null;
+    public ResponseEntity<List<Subscription>> getSubscriptionById(@PathVariable String subscriptionName) {
+    	List<Subscription> subscriptionList = new ArrayList<Subscription>();
         try {
             LOG.info("Subscription :" + subscriptionName + " fetch started");
-            subscription = subscriptionService.getSubscription(subscriptionName);
+            subscriptionList.add(subscriptionService.getSubscription(subscriptionName));
             LOG.info("Subscription :" + subscriptionName + " fetched");
-            return new ResponseEntity<Subscription>(subscription, HttpStatus.OK);
+            return new ResponseEntity<List<Subscription>> (subscriptionList, HttpStatus.OK);
         } catch (SubscriptionNotFoundException e) {
             LOG.error("Subscription :" + subscriptionName + " not found in records");
-            return new ResponseEntity<Subscription>(subscription, HttpStatus.OK);
+            return new ResponseEntity<List<Subscription>> (subscriptionList, HttpStatus.OK);
+            
         }
         
     }

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -69,7 +69,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             return new ResponseEntity<Subscription>(subscription, HttpStatus.OK);
         } catch (SubscriptionNotFoundException e) {
             LOG.error("Subscription :" + subscriptionName + " not found in records");
-            return new ResponseEntity<Subscription>(subscription, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<Subscription>(subscription, HttpStatus.OK);
         }
         
     }
@@ -124,7 +124,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
             return new ResponseEntity<List<Subscription>>(subscriptionList, HttpStatus.OK);
         } catch (SubscriptionNotFoundException e) {
             LOG.error(e.getLocalizedMessage());
-            return new ResponseEntity<List<Subscription>>(subscriptionList, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<List<Subscription>>(subscriptionList, HttpStatus.OK);
         }
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/model/Subscription.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Subscription.java
@@ -23,8 +23,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
     "notificationType",
     "repeat",
     "requirements",
-    "subscriptionName",
-    "timeout"
+    "subscriptionName"
 })
 public class Subscription {
 
@@ -42,8 +41,6 @@ public class Subscription {
     private List<Requirement> requirements = new ArrayList<Requirement>();
     @JsonProperty("subscriptionName")
     private String subscriptionName;
-    @JsonProperty("timeout")
-    private Integer timeout;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -187,26 +184,6 @@ public class Subscription {
         this.subscriptionName = subscriptionName;
     }
 
-    /**
-     * 
-     * @return
-     *     The timeout
-     */
-    @JsonProperty("timeout")
-    public Integer getTimeout() {
-        return timeout;
-    }
-
-    /**
-     * 
-     * @param timeout
-     *     The timeout
-     */
-    @JsonProperty("timeout")
-    public void setTimeout(Integer timeout) {
-        this.timeout = timeout;
-    }
-
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
@@ -224,7 +201,7 @@ public class Subscription {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(created).append(notificationMessage).append(notificationMeta).append(notificationType).append(repeat).append(requirements).append(subscriptionName).append(timeout).append(additionalProperties).toHashCode();
+        return new HashCodeBuilder().append(created).append(notificationMessage).append(notificationMeta).append(notificationType).append(repeat).append(requirements).append(subscriptionName).append(additionalProperties).toHashCode();
     }
 
     @Override
@@ -236,7 +213,7 @@ public class Subscription {
             return false;
         }
         Subscription rhs = ((Subscription) other);
-        return new EqualsBuilder().append(created, rhs.created).append(notificationMessage, rhs.notificationMessage).append(notificationMeta, rhs.notificationMeta).append(notificationType, rhs.notificationType).append(repeat, rhs.repeat).append(requirements, rhs.requirements).append(subscriptionName, rhs.subscriptionName).append(timeout, rhs.timeout).append(additionalProperties, rhs.additionalProperties).isEquals();
+        return new EqualsBuilder().append(created, rhs.created).append(notificationMessage, rhs.notificationMessage).append(notificationMeta, rhs.notificationMeta).append(notificationType, rhs.notificationType).append(repeat, rhs.repeat).append(requirements, rhs.requirements).append(subscriptionName, rhs.subscriptionName).append(additionalProperties, rhs.additionalProperties).isEquals();
     }
 
 }

--- a/src/main/resources/public/raml/common-schema.raml
+++ b/src/main/resources/public/raml/common-schema.raml
@@ -44,9 +44,6 @@ subscription: |
           },
           "subscriptionName":{
              "type":"string"
-          },
-          "timeout":{
-             "type":"integer"
           }
        },
        "type":"object"
@@ -99,9 +96,6 @@ subscriptionList: |
           },
           "subscriptionName":{
              "type":"string"
-          },
-          "timeout":{
-             "type":"integer"
           }
        },
        "type":"object"

--- a/src/main/resources/public/raml/subscription.raml
+++ b/src/main/resources/public/raml/subscription.raml
@@ -66,10 +66,11 @@
       get:
         description: Returns the subscription rules for given subscription name. 
         responses:
-          200:          
+          200:        
             body:
               application/json:
-                schema: subscription  
+                schema: subscriptionList
+              
         
               
       delete:

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionRestAPITest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionRestAPITest.java
@@ -108,10 +108,10 @@ public class SubscriptionRestAPITest {
         
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
         
-        Subscription subscription = mapper.readValue(result.getResponse().getContentAsString().toString(),
-                Subscription.class);
+        Subscription[] subscription = mapper.readValue(result.getResponse().getContentAsString().toString(),
+                Subscription[].class);
         assertEquals(HttpStatus.OK.value(), result.getResponse().getStatus());
-        assertEquals("Subscription_Test", subscription.getSubscriptionName());
+        assertEquals("Subscription_Test", subscription[0].getSubscriptionName());
     }
     
     @Test
@@ -125,7 +125,7 @@ public class SubscriptionRestAPITest {
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
         
         assertEquals(HttpStatus.OK.value(), result.getResponse().getStatus());
-        assertEquals("", result.getResponse().getContentAsString());
+        assertEquals("[]", result.getResponse().getContentAsString());
     }
     
     @Test

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionRestAPITest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionRestAPITest.java
@@ -124,7 +124,7 @@ public class SubscriptionRestAPITest {
         
         MvcResult result = mockMvc.perform(requestBuilder).andReturn();
         
-        assertEquals(HttpStatus.NOT_FOUND.value(), result.getResponse().getStatus());
+        assertEquals(HttpStatus.OK.value(), result.getResponse().getStatus());
         assertEquals("", result.getResponse().getContentAsString());
     }
     

--- a/src/test/resources/SubscriptionObject.json
+++ b/src/test/resources/SubscriptionObject.json
@@ -2,7 +2,6 @@
         "subscriptionName": "Subscription_1",
         "repeat": false,
         "created": "data-time",
-        "timeout": 12354,
         "notificationType": "REST_POST",
         "notificationMeta": "http://127.0.0.1:3000/ei/test_subscription_rest",
         "notificationMessage": "@",

--- a/src/test/resources/subscription.json
+++ b/src/test/resources/subscription.json
@@ -28,8 +28,7 @@
             "type" : "ARTIFACT_1"
         }
     ],
-    "subscriptionName" : "Subscription_Test",
-    "timeout" : 12354
+    "subscriptionName" : "Subscription_Test"
 },
 {
     "created" : "2017-07-27",
@@ -61,6 +60,5 @@
             "type" : "ARTIFACT_1"
         }
     ],
-    "subscriptionName" : "Subscription_Test_Modify",
-    "timeout" : 12354
+    "subscriptionName" : "Subscription_Test_Modify"
 }]


### PR DESCRIPTION
This solves the HTTP Request error in Firefox and WebConsole: "XML Parsing Error: no root element found Location: http://localhost:8090/subscriptions/testDummySubscription Line Number 1, Column 1:",,,when checking EI Backend Connection.

This occurs due to EI Backend response with empty String "" when the asked SubscriptionName was not found in the database. Empty string is not a valid JSON nor XML format.
Changed the RestApi getSubscriptionById() to return a list instead, so if no Subscription is found, then an empty list "[]" is returnen. Same way EI handle get all subscription RestApi, when there is no Subscription in Database.
Another way to return empy JSON with Spring MVC:
https://codingexplained.com/coding/java/spring-framework/returning-empty-json-object-spring-framework

But I guess we can use this implemented solution since it works and have been used in get all subscriptions EI RestApi entrypoint.

Changed also HTTP Message in EI RestApi when trying to add a subscription when the SubscriptionName already exists in database, from "Error: {"msg":"Duplicate Subscription","statusCode":400}"  to "Error: {"msg":"Subscription already exists","statusCode":400}".
