### PR TITLE
Fix null pointer exception

### DIFF
--- a/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
@@ -60,7 +60,7 @@ public class ProcessQueryParams {
         LOGGER.debug("The criteria is : " + criteria.toString());
         LOGGER.debug("The options is : " + options.toString());
         JSONArray resultAggregatedObject;
-        if (options.toString().equals("{}") || options.isNull()) {
+        if (options.isNull() || options.toString().equals("{}")) {
             resultAggregatedObject = processAggregatedObject.processQueryAggregatedObject(criteria.toString(), databaseName, aggregationCollectionName);
         } else {
             String result = "{ \"$and\" : [ " + criteria.toString() + "," + options.toString() + " ] }";

--- a/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
@@ -57,12 +57,13 @@ public class ProcessQueryParams {
     public JSONArray filterFormParam(JsonNode request) throws IOException {
         JsonNode criteria = request.get("criteria");
         JsonNode options = request.get("options");
-        LOGGER.debug("The criteria is : " + criteria.toString());
-        LOGGER.debug("The options is : " + options.toString());
+        LOGGER.debug("The criteria is : " + criteria.toString());        
         JSONArray resultAggregatedObject;
+        
         if (options.isNull() || options.toString().equals("{}")) {
             resultAggregatedObject = processAggregatedObject.processQueryAggregatedObject(criteria.toString(), databaseName, aggregationCollectionName);
         } else {
+            LOGGER.debug("The options is : " + options.toString());
             String result = "{ \"$and\" : [ " + criteria.toString() + "," + options.toString() + " ] }";
             resultAggregatedObject = processAggregatedObject.processQueryAggregatedObject(result, databaseName, aggregationCollectionName);
         }


### PR DESCRIPTION
options should not be required in a post free style query. but the order of options check requires it so we switch the order to check nullity first.