### PR TITLE
Upgrade Spring Boot to 4.0.4 for Tomcat 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>4.0.4</version>
         <relativePath /> <!-- .. lookup parent from repository -->
     </parent>
     <properties>
@@ -24,10 +24,6 @@
         <skipTests>false</skipTests>
         <skipITs>${skipTests}</skipITs>
         <skipUTs>${skipTests}</skipUTs>
-        <springBootVersion>2.7.5</springBootVersion>
-        <springLdapVersion>2.3.4.RELEASE</springLdapVersion>
-        <springSecurityVersion>5.5.2</springSecurityVersion>
-        <springSessionVersion>2.5.0</springSessionVersion>
         <forkCountTests>1</forkCountTests>
         <jackson.version>2.14.1</jackson.version>
     </properties>
@@ -79,7 +75,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${springBootVersion}</version>
             <exclusions>
             	<exclusion>
             		<groupId>org.apache.logging.log4j</groupId>
@@ -91,49 +86,48 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${springBootVersion}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                    <artifactId>spring-boot-starter-tomcat-runtime</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.ulisesbocchio</groupId>
             <artifactId>jasypt-spring-boot-starter</artifactId>
-            <version>2.1.2</version>
+            <version>3.0.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>${springBootVersion}</version>
+            <artifactId>spring-boot-starter-test-classic</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -149,8 +143,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-            <version>${springBootVersion}</version>
+            <artifactId>spring-boot-starter-tomcat-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
         
@@ -181,31 +174,27 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
-            <version>${springBootVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-data-mongodb</artifactId>
-            <version>${springSessionVersion}</version>
+            <version>3.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.ldap</groupId>
             <artifactId>spring-ldap-core</artifactId>
-            <version>${springLdapVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
-            <version>${springSecurityVersion}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>${springSecurityVersion}</version>
             <scope>test</scope>
         </dependency>
 
@@ -294,17 +283,10 @@
         </dependency>
         
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-boot-starter</artifactId>
-            <version>3.0.0</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.13</version>
             <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>1.7.3</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -314,6 +296,13 @@
             <scope>provided</scope>
         </dependency>
         
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>2.0.9</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -331,36 +320,46 @@
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-broker</artifactId>
-            <version>7.1.0</version>
+            <version>9.1.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sleepycat</groupId>
+                    <artifactId>je</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.qpid</groupId>
+                    <artifactId>qpid-broker-plugins-management-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.qpid</groupId>
+                    <artifactId>qpid-broker-plugins-websocket</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-broker-core</artifactId>
-            <version>7.1.0</version>
+            <version>9.1.0</version>
             <scope>test</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.apache.qpid/qpid-broker-plugins-management-http -->
-        <dependency>
-            <groupId>org.apache.qpid</groupId>
-            <artifactId>qpid-broker-plugins-management-http</artifactId>
-            <version>7.1.0</version>
-            <scope>test</scope>
-        </dependency>
+        <!-- qpid-broker-plugins-management-http removed: depends on Jetty 11
+             which conflicts with Jetty 12 from SB4. Not needed for embedded
+             AMQP broker in tests. See EIFA-9714 investigation. -->
 
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-broker-plugins-amqp-1-0-protocol</artifactId>
-            <version>7.1.0</version>
+            <version>9.1.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>qpid-broker-plugins-memory-store</artifactId>
-            <version>7.1.0</version>
+            <version>9.1.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -430,17 +429,24 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- Required by json-schema-validator for email format validation (javax.mail.internet.AddressException).
+             SB4 only provides jakarta.mail, so this bridges the gap. -->
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.6.2</version>
+            <scope>runtime</scope>
+        </dependency>
         
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
         </dependency>
 	    
         <dependency>
            <groupId>ch.qos.logback</groupId>
            <artifactId>logback-core</artifactId>
-           <version>1.2.13</version>
         </dependency>
 	    
     </dependencies>
@@ -468,15 +474,33 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${springBootVersion}</version>
             </plugin>
 
-            <!-- PhoenixNAP RAML Code Generator plugin used to generate sources 
-                from raml -->
+            <!-- PhoenixNAP RAML Code Generator plugin - generates controller
+                interfaces from RAML API definitions.
+
+                DISABLED (phase=none) since Spring Boot 4 / Tomcat 11 uplift:
+                - The plugin generates javax.* imports incompatible with Jakarta EE 10+
+                - Controller interfaces are now maintained manually in com.ericsson.ei.controller
+                - RAML source files are kept in src/main/resources/public/raml/ for reference
+                - To re-enable: change <phase>none</phase> to <phase>generate-sources</phase>,
+                  update the plugin to a Jakarta-compatible version, and regenerate controllers -->
             <plugin>
                 <groupId>com.phoenixnap.oss</groupId>
                 <artifactId>springmvc-raml-plugin</artifactId>
                 <version>${springmvcRamlVersion}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.fge</groupId>
+                        <artifactId>json-schema-validator</artifactId>
+                        <version>2.2.6</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>joda-time</groupId>
+                        <artifactId>joda-time</artifactId>
+                        <version>2.12.5</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <!-- path to raml file -->
                     <ramlPath>${ramlPath}</ramlPath>
@@ -498,7 +522,7 @@
                 <executions>
                     <execution>
                         <id>generate-springmvc-controllers</id>
-                        <phase>generate-sources</phase>
+                        <phase>none</phase>
                         <goals>
                             <goal>generate-springmvc-endpoints</goal>
                         </goals>

--- a/src/functionaltests/java/com/ericsson/ei/encryption/EncryptionSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/encryption/EncryptionSteps.java
@@ -16,7 +16,7 @@ import org.junit.Ignore;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.verify.VerificationTimes;
 import org.slf4j.Logger;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -33,7 +33,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: EncryptionSteps",
+        "spring.mongodb.database: EncryptionSteps",
         "failed.notifications.collection.name: EncryptionSteps-missedNotifications",
         "rabbitmq.exchange.name: EncryptionSteps-exchange",
         "rabbitmq.queue.suffix: EncryptionSteps"})
@@ -144,7 +144,7 @@ public class EncryptionSteps extends FunctionalTestBase {
                               .setBody(jsonDataAsString)
                               .performRequest();
         assertEquals("Expected to add subscription to EI", HttpStatus.OK.value(),
-                response.getStatusCodeValue());
+                response.getStatusCode().value());
     }
 
     private void validateSubscriptionsSuccessfullyAdded()
@@ -158,7 +158,7 @@ public class EncryptionSteps extends FunctionalTestBase {
                              .setEndpoint(endpoint)
                              .performRequest();
         assertEquals("Subscription successfully added in EI: ", HttpStatus.OK.value(),
-                response.getStatusCodeValue());
+                response.getStatusCode().value());
     }
 
     private List<String> getEventNamesToSend() {

--- a/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/trigger/SubscriptionNotificationSteps.java
@@ -26,12 +26,12 @@ import org.mockserver.model.Format;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import com.ericsson.ei.mongo.MongoCondition;
 import com.ericsson.ei.mongo.MongoDBHandler;
@@ -49,7 +49,7 @@ import util.IntegrationTestBase;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionNotificationSteps",
+        "spring.mongodb.database: SubscriptionNotificationSteps",
         "failed.notifications.collection.name: SubscriptionNotificationSteps-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionNotificationSteps-exchange",
         "rabbitmq.queue.suffix: SubscriptionNotificationSteps",
@@ -84,7 +84,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
     @Value("${aggregations.collection.name}")
     private String aggregatedCollectionName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Value("${failed.notifications.collection.name}")
@@ -133,7 +133,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
                              .setEndpoint(EI_SUBSCRIPTIONS_ENDPOINT)
                              .performRequest();
         assertEquals("EI rest API status code: ", HttpStatus.OK.value(),
-                response.getStatusCodeValue());
+                response.getStatusCode().value());
     }
 
     @Given("Mail server is up")
@@ -225,7 +225,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
                              .setEndpoint(MAILHOG_SERVER_ENDPOINT)
                              .performRequest();
         assertEquals("EI rest API status code: ", HttpStatus.OK.value(),
-                response.getStatusCodeValue());
+                response.getStatusCode().value());
         
         
         JSONArray mails =  new JSONArray(response.getBody().toString());
@@ -312,7 +312,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
                               .setBody(jsonDataAsString)
                               .performRequest();
         assertEquals("Expected to add subscription to EI", HttpStatus.OK.value(),
-                response.getStatusCodeValue());
+                response.getStatusCode().value());
     }
 
     /**
@@ -331,7 +331,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
                              .setEndpoint(EI_SUBSCRIPTIONS_ENDPOINT)
                              .performRequest();
         assertEquals("Subscription successfully added in EI: ", HttpStatus.OK.value(),
-                response.getStatusCodeValue());
+                response.getStatusCode().value());
         LOGGER.debug("Checking that response contains all subscriptions");
         for (String subscriptionName : subscriptionNames) {
             assertTrue(response.toString().contains(subscriptionName));
@@ -399,7 +399,7 @@ public class SubscriptionNotificationSteps extends FunctionalTestBase {
      * Setting up the needed endpoints for the functional test.
      */
     private void setupRestEndpoints() {
-        int port = SocketUtils.findAvailableTcpPort();
+        int port = TestSocketUtils.findAvailableTcpPort();
         restServer = startClientAndServer(port);
 
         LOGGER.debug(

--- a/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/notifications/ttl/TestTTLSteps.java
@@ -21,9 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import com.ericsson.ei.exception.AuthenticationException;
 import com.ericsson.ei.exception.MongoDBConnectionException;
@@ -51,7 +51,7 @@ import io.cucumber.java.en.When;
         "failed.notifications.collection.ttl: 1",
         "aggregations.collection.ttl: 1",
         "notification.retry: 1",
-        "spring.data.mongodb.database: TestTTLSteps",
+        "spring.mongodb.database: TestTTLSteps",
         "failed.notifications.collection.name: TestTTLSteps-failedNotifications",
         "rabbitmq.exchange.name: TestTTLSteps-exchange",
         "rabbitmq.queue.suffix: TestTTLSteps",
@@ -84,7 +84,7 @@ public class TestTTLSteps extends FunctionalTestBase {
     @Value("${failed.notifications.collection.name}")
     private String failedNotificationCollection;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Value("${aggregations.collection.name}")
@@ -227,7 +227,7 @@ public class TestTTLSteps extends FunctionalTestBase {
      * to trigger retries of POST request
      */
     private void setUpMockServer() {
-        int port = SocketUtils.findAvailableTcpPort();
+        int port = TestSocketUtils.findAvailableTcpPort();
         clientAndServer = ClientAndServer.startClientAndServer(port);
         LOGGER.debug("Setting up mockServerClient with port " + port);
         mockServerClient = new MockServerClient(BASE_URL, port);

--- a/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/query/QueryAggregatedObjectsTestSteps.java
@@ -13,8 +13,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -37,7 +37,7 @@ import io.cucumber.java.en.Then;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: QueryAggregatedObjectsTestSteps",
+        "spring.mongodb.database: QueryAggregatedObjectsTestSteps",
         "failed.notifications.collection.name: QueryAggregatedObjectsTestSteps-failedNotifications",
         "rabbitmq.exchange.name: QueryAggregatedObjectsTestSteps-exchange",
         "rabbitmq.queue.suffix: QueryAggregatedObjectsTestSteps" })
@@ -71,7 +71,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
     @Autowired
     private MongoDBHandler mongoDBHandler;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Value("${aggregations.collection.name}")
@@ -137,7 +137,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .addHeader("Accept", CONTENT_TYPE)
                              .setEndpoint(EntryPointConstantsUtils.AGGREGATED_OBJECTS + "/" + documentId).performRequest();
 
-        LOGGER.debug("Response of /aggregated-objects RestApi, Status Code: " + response.getStatusCodeValue()
+        LOGGER.debug("Response of /aggregated-objects RestApi, Status Code: " + response.getStatusCode().value()
                 + "\nResponse: " + response.getBody().toString());
 
         JsonNode jsonNodeResult = objMapper.readValue(response.getBody().toString(),
@@ -149,7 +149,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                                                                  .get("testCaseFinishedEventId")
                                                                  .asText();
 
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertEquals(
                 "Failed to compare actual Aggregated Object TestCaseFinishedEventId:\n"
                         + actualTestCaseFinishedEventId
@@ -175,7 +175,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .performRequest();
 
         String responseAsString = response.getBody().toString();
-        int responseStatusCode = response.getStatusCodeValue();
+        int responseStatusCode = response.getStatusCode().value();
         LOGGER.debug("Response of /queryAggregatedObject RestApi, Status Code: "
                 + responseStatusCode + "\nResponse: "
                 + responseAsString);
@@ -214,7 +214,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                                   .setBody(formattedQuery)
                                   .performRequest();
 
-            LOGGER.debug("Response of /query RestApi, Status Code: " + response.getStatusCodeValue()
+            LOGGER.debug("Response of /query RestApi, Status Code: " + response.getStatusCode().value()
                     + "\nResponse: "
                     + response.getBody().toString());
 
@@ -226,7 +226,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
             String actualAggrObjId = aggrObjResponse.get("id").asText();
             LOGGER.debug("AggregatedObject id from Response: " + actualAggrObjId);
 
-            assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+            assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
             assertEquals(
                     "Failed to compare actual Aggregated Object Id:\n" + actualAggrObjId
                             + "\nwith expected Aggregated Object Id:\n" + expectedAggrId,
@@ -254,7 +254,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .performRequest();
 
         String responseAsString = response.getBody().toString();
-        int responseStatusCode = response.getStatusCodeValue();
+        int responseStatusCode = response.getStatusCode().value();
         LOGGER.debug(
                 "Response of /query RestApi, Status Code: " + responseStatusCode + "\nResponse: "
                         + responseAsString);
@@ -296,7 +296,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .performRequest();
 
         String responseAsString = response.getBody().toString();
-        int responseStatusCode = response.getStatusCodeValue();
+        int responseStatusCode = response.getStatusCode().value();
         LOGGER.debug("Response of /failed-notifications RestApi, Status Code: " + responseStatusCode
                 + "\nResponse: " + responseAsString);
 
@@ -308,7 +308,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                                                             .get(0)
                                                             .get("testCaseStartedEventId")
                                                             .asText();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertEquals(
                 "Differences between actual Failed Notification response TestCaseStartedEventId:\n"
                         + actualTestCaseStartedEventId
@@ -337,7 +337,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                              .performRequest();
 
         String responseAsString = response.getBody().toString();
-        int responseStatusCode = response.getStatusCodeValue();
+        int responseStatusCode = response.getStatusCode().value();
         LOGGER.debug("Response of /failed-notifications RestApi, Status Code: " + responseStatusCode
                 + "\nResponse: " + responseAsString);
 
@@ -368,12 +368,12 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                                   .setBody(query)
                                   .performRequest();
 
-            LOGGER.debug("Response of /query RestApi, Status Code: " + response.getStatusCodeValue()
+            LOGGER.debug("Response of /query RestApi, Status Code: " + response.getStatusCode().value()
                     + "\nResponse: "
                     + response.getBody().toString());
 
             String responseAsString = response.getBody().toString();
-            int responseStatusCode = response.getStatusCodeValue();
+            int responseStatusCode = response.getStatusCode().value();
 
             assertEquals(HttpStatus.OK.value(), responseStatusCode);
             assertEquals("Failed to compare actual response:\n" + responseAsString
@@ -414,12 +414,12 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                                   .setBody(query)
                                   .performRequest();
 
-            LOGGER.debug("Response of /query RestApi, Status : " + response.getStatusCodeValue()
+            LOGGER.debug("Response of /query RestApi, Status : " + response.getStatusCode().value()
                     + "\nResponse: "
                     + response.getBody().toString());
 
             String responseAsString = response.getBody().toString();
-            int responseStatusCode = response.getStatusCodeValue();
+            int responseStatusCode = response.getStatusCode().value();
 
             assertEquals(HttpStatus.OK.value(), responseStatusCode);
             assertEquals(
@@ -452,7 +452,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
                               .setBody(formattedQuery)
                               .performRequest();
 
-        LOGGER.debug("Response of /aggregated-objects/query RestApi, Status Code: " + response.getStatusCodeValue()
+        LOGGER.debug("Response of /aggregated-objects/query RestApi, Status Code: " + response.getStatusCode().value()
                 + "\nResponse: "
                 + response.getBody().toString());
 
@@ -462,7 +462,7 @@ public class QueryAggregatedObjectsTestSteps extends FunctionalTestBase {
 
         JsonNode confidenceLevels = aggrObjResponse.get("confidenceLevels").get(1);
 
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertEquals("Failed to retrieve the latest confidence level.", "readyForDelivery",
                 confidenceLevels.get("name").asText());
         assertEquals("Failed to retrieve the latest confidence level.", "SUCCESS",

--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/configuration/RabbitMQConfigurationTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/configuration/RabbitMQConfigurationTestSteps.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import com.ericsson.ei.handlers.EventHandler;
 import com.ericsson.ei.handlers.RMQHandler;
@@ -35,10 +35,11 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: RabbitMQConfigurationTestSteps",
+        "spring.mongodb.database: RabbitMQConfigurationTestSteps",
         "missedNotificationDataBaseName: RabbitMQConfigurationTestSteps-missedNotifications",
         "rabbitmq.exchange.name: RabbitMQConfigurationTestSteps-exchange",
-        "rabbitmq.consumerName: RabbitMQConfigurationTestStepsConsumer" })
+        "rabbitmq.consumerName: RabbitMQConfigurationTestStepsConsumer",
+        "rabbitmq.queue.suffix: RabbitMQConfigurationTestSteps" })
 public class RabbitMQConfigurationTestSteps extends FunctionalTestBase {
 
     @Value("${rabbitmq.port}")
@@ -61,7 +62,7 @@ public class RabbitMQConfigurationTestSteps extends FunctionalTestBase {
 
     @Given("^We are connected to message bus$")
     public void connect_to_message_bus() throws Exception {
-        int port = SocketUtils.findAvailableTcpPort();
+        int port = TestSocketUtils.findAvailableTcpPort();
         String config = "src/functionaltests/resources/configs/qpidConfig.json";
         File qpidConfig = new File(config);
         amqpBroker = new AMQPBrokerManager(qpidConfig.getAbsolutePath(), port);

--- a/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rabbitmq/connection/RabbitMQTestConnectionSteps.java
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import com.ericsson.ei.handlers.EventHandler;
 import com.ericsson.ei.handlers.RMQHandler;
@@ -43,7 +43,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: RabbitMQTestConnectionSteps",
+        "spring.mongodb.database: RabbitMQTestConnectionSteps",
         "bindingkeys.collection.name: RabbitMQConfigurationTestSteps-bindingKeys",
         "failed.notifications.collection.name: RabbitMQTestConnectionSteps-failedNotifications",
         "rabbitmq.exchange.name: RabbitMQTestConnectionSteps-exchange",
@@ -69,7 +69,7 @@ public class RabbitMQTestConnectionSteps extends FunctionalTestBase {
     @Autowired
     EventHandler eventHandler;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String dataBaseName;
 
     @Value("${bindingkeys.collection.name}")
@@ -80,7 +80,7 @@ public class RabbitMQTestConnectionSteps extends FunctionalTestBase {
 
     @Given("^We are connected to message bus$")
     public void connect_to_message_bus() throws Exception {
-        int port = SocketUtils.findAvailableTcpPort();
+        int port = TestSocketUtils.findAvailableTcpPort();
         String config = "src/functionaltests/resources/configs/qpidConfig.json";
         File qpidConfig = new File(config);
         amqpBroker = new AMQPBrokerManager(qpidConfig.getAbsolutePath(), port);

--- a/src/functionaltests/java/com/ericsson/ei/restendpoints/RestEndpointsTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/restendpoints/RestEndpointsTestSteps.java
@@ -3,8 +3,8 @@ package com.ericsson.ei.restendpoints;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Ignore;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
@@ -22,7 +22,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: RestEndpointsTestSteps",
+        "spring.mongodb.database: RestEndpointsTestSteps",
         "failed.notifications.collection.name: RestEndpointsTestSteps-failedNotifications",
         "rabbitmq.exchange.name: RestEndpointsTestSteps-exchange",
         "rabbitmq.queue.suffix: RestEndpointsTestSteps" })
@@ -85,7 +85,7 @@ public class RestEndpointsTestSteps extends FunctionalTestBase {
 
     @Then("^Request should get response code (\\d+)$")
     public void request_should_get_response_code(int expectedStatusCode) throws Throwable {
-        int actualStatusCode = response.getStatusCodeValue();
+        int actualStatusCode = response.getStatusCode().value();
         assertEquals("EI rest API status code: ", expectedStatusCode, actualStatusCode);
         response = null;
     }

--- a/src/functionaltests/java/com/ericsson/ei/rules/RuleTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rules/RuleTestSteps.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
@@ -28,7 +28,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: RuleTestSteps",
+        "spring.mongodb.database: RuleTestSteps",
         "failed.notifications.collection.name: RuleTestSteps-failedNotifications",
         "rabbitmq.exchange.name: RuleTestSteps-exchange",
         "rabbitmq.queue.suffix: RuleTestSteps" })
@@ -98,7 +98,7 @@ public class RuleTestSteps extends FunctionalTestBase {
 
     @Then("^get response code of (\\d+)$")
     public void get_response_code_of(int statusCode) throws Throwable {
-        assertEquals(statusCode, response.getStatusCodeValue());
+        assertEquals(statusCode, response.getStatusCode().value());
     }
 
     @Then("^get content \"([^\"]*)\"$")
@@ -133,7 +133,7 @@ public class RuleTestSteps extends FunctionalTestBase {
                                                        .setEndpoint(endpoint)
                                                        .performRequest();
 
-        assertEquals(statusCode, apiResponse.getStatusCodeValue());
+        assertEquals(statusCode, apiResponse.getStatusCode().value());
         assertEquals(responseBody, apiResponse.getBody());
     }
 

--- a/src/functionaltests/java/com/ericsson/ei/rules/RulesHandlerSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/rules/RulesHandlerSteps.java
@@ -13,7 +13,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
@@ -24,7 +24,7 @@ import io.cucumber.java.en.Then;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: RulesHandlerSteps",
+        "spring.mongodb.database: RulesHandlerSteps",
         "failed.notifications.collection.name: RulesHandlerSteps-failedNotifications",
         "rabbitmq.exchange.name: RulesHandlerSteps-exchange",
         "rabbitmq.queue.suffix: RulesHandlerSteps" })
@@ -103,7 +103,7 @@ public class RulesHandlerSteps {
      * Setting up the needed endpoints for the functional test.
      */
     private void setupRestEndpoints() {
-        port = SocketUtils.findAvailableTcpPort();
+        port = TestSocketUtils.findAvailableTcpPort();
         restServer = startClientAndServer(port);
 
         LOGGER.debug("Setting up endpoints on host '" + HOST + "' and port '" + port + "'");

--- a/src/functionaltests/java/com/ericsson/ei/scaling/ScalingAndFailoverSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/scaling/ScalingAndFailoverSteps.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Ignore;
@@ -17,8 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.MapPropertySource;
@@ -29,7 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.ericsson.ei.App;
@@ -43,7 +43,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: ScalingAndFailoverSteps",
+        "spring.mongodb.database: ScalingAndFailoverSteps",
         "failed.notifications.collection.name: ScalingAndFailoverSteps-failedNotifications",
         "rabbitmq.exchange.name: ScalingAndFailoverSteps-exchange",
         "rabbitmq.queue.suffix: ScalingAndFailoverSteps" })
@@ -149,9 +149,13 @@ public class ScalingAndFailoverSteps extends FunctionalTestBase {
         @Override
         @SuppressWarnings("unchecked")
         public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-            PropertySource ps = new MapPropertySource("spring.data.mongodb.database",
-                    Collections.singletonMap("spring.data.mongodb.database", "ScalingAndFailoverSteps"));
+            PropertySource ps = new MapPropertySource("spring.mongodb.database",
+                    Collections.singletonMap("spring.mongodb.database", "ScalingAndFailoverSteps"));
             configurableApplicationContext.getEnvironment().getPropertySources().addFirst(ps);
+
+            PropertySource ps0 = new MapPropertySource("spring.mongodb.database",
+                    Collections.singletonMap("spring.mongodb.database", "ScalingAndFailoverSteps"));
+            configurableApplicationContext.getEnvironment().getPropertySources().addFirst(ps0);
 
             PropertySource ps1 = new MapPropertySource("rabbitmq.exchange.name",
                     Collections.singletonMap("rabbitmq.exchange.name", "ScalingAndFailoverSteps-exchange"));
@@ -161,7 +165,7 @@ public class ScalingAndFailoverSteps extends FunctionalTestBase {
                     Collections.singletonMap("rabbitmq.queue.suffix", "ScalingAndFailoverSteps"));
             configurableApplicationContext.getEnvironment().getPropertySources().addFirst(ps2);
 
-            int port = SocketUtils.findAvailableTcpPort();
+            int port = TestSocketUtils.findAvailableTcpPort();
             portList.add(port);
             PropertySource ps3 = new MapPropertySource("server.port", Collections.singletonMap("server.port", port));
             configurableApplicationContext.getEnvironment().getPropertySources().addFirst(ps3);

--- a/src/functionaltests/java/com/ericsson/ei/status/StatusTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/status/StatusTestSteps.java
@@ -31,7 +31,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: StatusSteps",
+        "spring.mongodb.database: StatusSteps",
         "failed.notifications.collection.name: StatusSteps-missedNotifications",
         "rabbitmq.exchange.name: StatusSteps-exchange",
         "rabbitmq.queue.suffix: StatusSteps" })

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/authentication/AuthenticationSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/authentication/AuthenticationSteps.java
@@ -18,10 +18,10 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.tomcat.util.codec.binary.Base64;
+import java.util.Base64;
 import org.json.JSONObject;
 import org.junit.Ignore;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -42,7 +42,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: AuthenticationSteps",
+        "spring.mongodb.database: AuthenticationSteps",
         "failed.notifications.collection.name: AuthenticationSteps-failedNotifications",
         "rabbitmq.exchange.name: AuthenticationSteps-exchange",
         "rabbitmq.queue.suffix: AuthenticationSteps",
@@ -66,7 +66,7 @@ public class AuthenticationSteps extends FunctionalTestBase {
         httpRequest.setHost(hostName).setPort(applicationPort).setEndpoint("/authentication/logout");
 
         String auth = "gauss:password";
-        String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");
+        String encodedAuth = new String(Base64.getEncoder().encode(auth.getBytes()), "UTF-8");
         httpRequest.addHeader("Authorization", "Basic " + encodedAuth);
         httpRequest.performRequest();
     }
@@ -105,7 +105,7 @@ public class AuthenticationSteps extends FunctionalTestBase {
     @When("^username \"([^\"]*)\" and password \"([^\"]*)\" is used as credentials$")
     public void with_credentials(String username, String password) throws Throwable {
         String auth = username + ":" + password;
-        String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");
+        String encodedAuth = new String(Base64.getEncoder().encode(auth.getBytes()), "UTF-8");
         httpRequest.addHeader("Authorization", "Basic " + encodedAuth);
     }
 

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/bulk/SubscriptionBulkSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/bulk/SubscriptionBulkSteps.java
@@ -8,7 +8,7 @@ import org.apache.commons.io.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Ignore;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
@@ -26,7 +26,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionBulkSteps",
+        "spring.mongodb.database: SubscriptionBulkSteps",
         "failed.notifications.collection.name: SubscriptionBulkSteps-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionBulkSteps-exchange",
         "rabbitmq.queue.suffix: SubscriptionBulkSteps",

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/content/SubscriptionContentSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/content/SubscriptionContentSteps.java
@@ -4,12 +4,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -29,7 +29,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionContentSteps",
+        "spring.mongodb.database: SubscriptionContentSteps",
         "failed.notifications.collection.name: SubscriptionContentSteps-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionContentSteps-exchange",
         "rabbitmq.queue.suffix: SubscriptionContentSteps" })
@@ -81,14 +81,14 @@ public class SubscriptionContentSteps extends FunctionalTestBase {
 
     @Then("^The subscription is created successfully$")
     public void the_subscription_is_created_successfully() throws Throwable {
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
     }
 
     @And("^Valid subscription \"([A-Za-z0-9_]+)\" exists$")
     public void valid_subscription_exists(String subscriptionName) throws Throwable {
         getRequest.setEndpoint("/subscriptions/" + subscriptionName);
         response = getRequest.performRequest();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
     }
 
     // SCENARIO 2
@@ -97,7 +97,7 @@ public class SubscriptionContentSteps extends FunctionalTestBase {
     public void subscription_already_exists(String subscriptionName) throws Throwable {
         getRequest.setEndpoint("/subscriptions/" + subscriptionName);
         response = getRequest.performRequest();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
     }
 
     @When("^I create a duplicate subscription with \"(.*)\"$")
@@ -108,7 +108,7 @@ public class SubscriptionContentSteps extends FunctionalTestBase {
 
     @Then("^Duplicate subscription is rejected$")
     public void duplicate_subscription_is_rejected() {
-        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
     }
 
     @And("^\"([A-Za-z0-9_]+)\" is not duplicated$")
@@ -126,14 +126,14 @@ public class SubscriptionContentSteps extends FunctionalTestBase {
     public void delete_subscription(String subscriptionName) throws Throwable {
         deleteRequest.setEndpoint("/subscriptions/" + subscriptionName);
         response = deleteRequest.performRequest();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
     }
 
     @And("^Subscriptions does not exist$")
     public void subscriptions_does_not_exist() throws Throwable {
         getRequest.setEndpoint("/subscriptions");
         response = getRequest.performRequest();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertEquals("[]", response.getBody().toString());
     }
 
@@ -145,15 +145,19 @@ public class SubscriptionContentSteps extends FunctionalTestBase {
 
     @Then("^The invalid subscription is rejected$")
     public void invalid_subscription_is_rejected() {
-        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
     }
 
     @And("^The invalid subscription does not exist$")
     public void invalid_subscription_does_not_exist() throws Throwable {
-        String invalidName = "#Subscription-&-with-&-mal-&-formatted-&-name";
-        getRequest.setEndpoint("/subscriptions/" + invalidName);
+        // SB4/Spring 7 disables trailing slash matching. The original test used
+        // "#Subscription-&-..." which caused URI fragment truncation, sending the
+        // request to "/subscriptions/" (trailing slash). This no longer matches
+        // "/subscriptions" in SB4. Instead, query all subscriptions to verify the
+        // invalid one was not persisted.
+        getRequest.setEndpoint("/subscriptions");
         response = getRequest.performRequest();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
         assertEquals("[]", response.getBody().toString());
     }
 
@@ -168,7 +172,7 @@ public class SubscriptionContentSteps extends FunctionalTestBase {
 
     @Then("^The subscription with missing field is rejected$")
     public void the_subscription_with_missing_field_is_rejected() throws Throwable {
-        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatusCode().value());
     }
 
 }

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/crud/SubscriptionCRUDSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/crud/SubscriptionCRUDSteps.java
@@ -10,8 +10,8 @@ import org.json.JSONObject;
 import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -31,7 +31,7 @@ import io.cucumber.java.en.When;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionCRUDSteps",
+        "spring.mongodb.database: SubscriptionCRUDSteps",
         "failed.notifications.collection.name: SubscriptionCRUDSteps-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionCRUDSteps-exchange",
         "rabbitmq.queue.suffix: SubscriptionCRUDSteps" })

--- a/src/functionaltests/java/com/ericsson/ei/subscriptions/repeatHandler/SubscriptionRepeatHandlerSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/subscriptions/repeatHandler/SubscriptionRepeatHandlerSteps.java
@@ -15,7 +15,7 @@ import org.json.JSONObject;
 import org.junit.Ignore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -41,7 +41,7 @@ import io.cucumber.java.en.When;
 @Ignore
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/TestExecutionObjectRules.json",
-        "spring.data.mongodb.database: SubscriptionRepeatHandlerSteps",
+        "spring.mongodb.database: SubscriptionRepeatHandlerSteps",
         "failed.notifications.collection.name: SubscriptionRepeatHandlerSteps-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionRepeatHandlerSteps-exchange",
         "rabbitmq.consumer.name: SubscriptionRepeatHandlerStepsConsumer" })
@@ -64,7 +64,7 @@ public class SubscriptionRepeatHandlerSteps extends FunctionalTestBase {
     @Value("${aggregations.collection.name}")
     private String collectionName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String dataBaseName;
 
     @Value("${subscriptions.repeat.handler.collection.name}")
@@ -126,7 +126,7 @@ public class SubscriptionRepeatHandlerSteps extends FunctionalTestBase {
                                                .addHeader("Accept", "application/json")
                                                .setEndpoint(subscriptionEndPoint + name)
                                                .performRequest();
-        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCode().value());
     }
 
     @Then("^Check in MongoDB RepeatFlagHandler collection that the subscription has been removed$")

--- a/src/functionaltests/java/com/ericsson/ei/templates/TemplatesTestSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/templates/TemplatesTestSteps.java
@@ -8,8 +8,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +29,7 @@ import io.cucumber.java.en.Then;
 
 @Ignore
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TemplatesTestSteps",
+        "spring.mongodb.database: TemplatesTestSteps",
         "rabbitmq.exchange.name: TemplatesTestSteps-exchange",
         "rabbitmq.queue.suffix: TemplatesTestSteps" })
 @AutoConfigureMockMvc

--- a/src/functionaltests/java/com/ericsson/ei/threadingAndWaitlistRepeat/ThreadingAndWaitlistRepeatSteps.java
+++ b/src/functionaltests/java/com/ericsson/ei/threadingAndWaitlistRepeat/ThreadingAndWaitlistRepeatSteps.java
@@ -30,7 +30,7 @@ import io.cucumber.java.en.Then;
         "waitlist.collection.ttl: 60",
         "waitlist.resend.initial.delay: 500",
         "waitlist.resend.fixed.rate: 1000",
-        "spring.data.mongodb.database: ThreadingAndWaitlistRepeatSteps",
+        "spring.mongodb.database: ThreadingAndWaitlistRepeatSteps",
         "failed.notifications.collection.name: ThreadingAndWaitlistRepeatSteps-failedNotifications",
         "rabbitmq.exchange.name: ThreadingAndWaitlistRepeatSteps-exchange",
         "rabbitmq.queue.suffix: ThreadingAndWaitlistRepeatSteps",

--- a/src/functionaltests/java/com/ericsson/ei/utils/DataBaseManager.java
+++ b/src/functionaltests/java/com/ericsson/ei/utils/DataBaseManager.java
@@ -8,7 +8,7 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.mongodb.autoconfigure.MongoProperties;
 import org.springframework.stereotype.Component;
 
 import com.google.gson.JsonObject;
@@ -26,7 +26,7 @@ public class DataBaseManager {
     private static final int MAX_WAIT_TIME_MILLISECONDS = 30000;
     private static final int RETRY_EVERY_X_MILLISECONDS = 1000;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Value("${event.object.map.collection.name}")

--- a/src/functionaltests/java/com/ericsson/ei/utils/TestConfigs.java
+++ b/src/functionaltests/java/com/ericsson/ei/utils/TestConfigs.java
@@ -3,12 +3,11 @@ package com.ericsson.ei.utils;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.tomcat.util.codec.binary.Base64;
-import org.apache.tomcat.util.codec.binary.StringUtils;
+import java.util.Base64;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.MongoClient;
@@ -32,7 +31,7 @@ public class TestConfigs {
             return;
         }
         // Generates a random port for amqpBroker and starts up a new broker
-        int port = SocketUtils.findAvailableTcpPort();
+        int port = TestSocketUtils.findAvailableTcpPort();
 
         System.setProperty("rabbitmq.port", Integer.toString(port));
         System.setProperty("rabbitmq.user", "guest");
@@ -57,7 +56,7 @@ public class TestConfigs {
             final ListDatabasesIterable<Document> list = mongoClient.listDatabases();
             final MongoCursor<Document> iter = list.iterator();
             final String port = "" + iter.getServerAddress().getPort();
-            System.setProperty("spring.data.mongodb.port", port);
+            System.setProperty("spring.mongodb.port", port);
             LOGGER.debug("Started embedded Mongo DB for tests on port: " + port);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
@@ -65,7 +64,7 @@ public class TestConfigs {
     }
 
     protected static void setAuthorization() {
-        String password = StringUtils.newStringUtf8(Base64.encodeBase64("password".getBytes()));
+        String password = new String(Base64.getEncoder().encode("password".getBytes()), java.nio.charset.StandardCharsets.UTF_8);
         System.setProperty("ldap.password", password);
     }
 

--- a/src/functionaltests/resources/application.properties
+++ b/src/functionaltests/resources/application.properties
@@ -7,13 +7,10 @@ server.port: 8090
 logging.level.root: OFF
 logging.level.org.springframework.web: ERROR
 logging.level.com.ericsson.ei: ERROR
-
 rules.path: /rules/ArtifactRules-Eiffel-Agen-Version.json
 rules.replacement.marker: %IdentifyRulesEventId%
-
 # WARNING! Do not enable this in a production environment!
 test.aggregation.enabled: false
-
 rabbitmq.host: localhost
 rabbitmq.port: 5672
 rabbitmq.user: myuser
@@ -26,16 +23,12 @@ rabbitmq.consumer.name: messageConsumer
 rabbitmq.queue.durable: true
 rabbitmq.binding.key: #
 rabbitmq.waitlist.queue.suffix: waitList
-
 bindingkeys.collection.name: binding_keys
-
 encrypted.mongodb.password: ENC(okI09jIPnYFCSdLvi08bK8PfTTSmwMzs)
-spring.data.mongodb.uri: mongodb://admin:${encrypted.mongodb.password}@localhost:27016
-spring.data.mongodb.database: eiffel_intelligence
-
+spring.mongodb.uri: mongodb://admin:${encrypted.mongodb.password}@localhost:27016
+spring.mongodb.database: eiffel_intelligence
 server.session.timeout: 1200
 sessions.collection.name: sessions
-
 aggregations.collection.name: aggregations
 aggregations.collection.ttl: 600
 event.object.map.collection.name: event_object_map
@@ -48,20 +41,16 @@ waitlist.resend.fixed.rate: 15000
 failed.notifications.collection.name: failed_notifications
 failed.notifications.collection.ttl: 600
 notification.retry: 3
-
 email.sender: noreply@domain.com
 email.subject: Email Subscription Notification
-
 spring.mail.host: localhost
 spring.mail.port: 1025
 spring.mail.username:
 spring.mail.password:
 spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
-
-event.repository.url: http://localhost:8084/search/
+event.repository.url: http://localhost:8094/search/
 event.repository.shallow: true
-
 ldap.enabled: false
 ldap.server.list: [{\
         "url": "",\
@@ -70,15 +59,15 @@ ldap.server.list: [{\
         "password": "",\
         "user.filter": ""\
     }]
-
 ### DEVELOPER SETTINGS
-
 spring.mongodb.embedded.version: 3.4.1
 # We remove the embedded mongodb in tests since in most of them we set up our own before Spring
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
-
 threads.core.pool.size: 100
 threads.queue.capacity: 5000
 threads.max.pool.size: 150
 scheduled.threadpool.size: 100
+# Jasypt 3.0.5 backward compat
+jasypt.encryptor.algorithm=PBEWithMD5AndDES
+jasypt.encryptor.iv-generator-classname=org.jasypt.iv.NoIvGenerator

--- a/src/functionaltests/resources/configs/password.properties
+++ b/src/functionaltests/resources/configs/password.properties
@@ -1,1 +1,2 @@
 guest:guest
+myuser:myuser

--- a/src/functionaltests/resources/configs/qpidConfig.json
+++ b/src/functionaltests/resources/configs/qpidConfig.json
@@ -1,6 +1,6 @@
 {
   "name": "Embedded Broker",
-  "modelVersion": "7.1",
+  "modelVersion": "9.0",
   "authenticationproviders" : [ {
     "name" : "passwordFile",
     "path" : "${qpid.pass_file}",
@@ -27,6 +27,6 @@
     "name" : "default",
     "type" : "Memory",
     "defaultVirtualHostNode" : "true",
-    "virtualHostInitialConfiguration" : "{\"type\" : \"Memory\",\"name\" : \"default\",\"modelVersion\" : \"7.1\"}"
+    "virtualHostInitialConfiguration" : "{\"type\" : \"Memory\",\"name\" : \"default\",\"modelVersion\" : \"9.0\"}"
   }]
 }

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/flow/FlowStepsIT.java
@@ -291,7 +291,7 @@ public class FlowStepsIT extends IntegrationTestBase {
                    .setBody(subscriptionObject.getAsSubscriptions().toString());
 
         ResponseEntity<String> response = postRequest.performRequest();
-        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(200, response.getStatusCode().value());
     }
 
     @Override

--- a/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
+++ b/src/integrationtests/java/com/ericsson/ei/integrationtests/notification/FailedNotificationStepsIT.java
@@ -124,7 +124,7 @@ public class FailedNotificationStepsIT extends IntegrationTestBase {
                    .setBody(subscriptionObject.getAsSubscriptions().toString());
 
         ResponseEntity response = postRequest.performRequest();
-        int statusCode = Integer.valueOf(response.getStatusCodeValue());
+        int statusCode = response.getStatusCode();
         assertEquals(200, statusCode);
     }
 

--- a/src/integrationtests/java/util/IntegrationTestBase.java
+++ b/src/integrationtests/java/util/IntegrationTestBase.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -38,7 +38,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.support.AbstractTestExecutionListener;
 
@@ -67,7 +67,7 @@ public abstract class IntegrationTestBase extends AbstractTestExecutionListener 
     @LocalServerPort
     protected int port;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
     @Value("${rabbitmq.host}")
     private String rabbitMqHost;

--- a/src/integrationtests/resources/application.properties
+++ b/src/integrationtests/resources/application.properties
@@ -7,13 +7,10 @@ server.port: 8090
 logging.level.root: OFF
 logging.level.org.springframework.web: ERROR
 logging.level.com.ericsson.ei: ERROR
-
 rules.path: /rules/ArtifactRules-Eiffel-Agen-Version.json
 rules.replacement.marker: %IdentifyRulesEventId%
-
 # WARNING! Do not enable this in a production environment!
 test.aggregation.enabled: false
-
 rabbitmq.host: localhost
 rabbitmq.port: 5672
 rabbitmq.user: myuser
@@ -26,16 +23,12 @@ rabbitmq.consumer.name: messageConsumer
 rabbitmq.queue.durable: true
 rabbitmq.binding.key: #
 rabbitmq.waitlist.queue.suffix: waitList
-
 bindingkeys.collection.name: binding_keys
-
 encrypted.mongodb.password: ENC(en2h9ZQlZEuWyyfiTVrOPcQbRTwcXxOJ)
-spring.data.mongodb.uri: mongodb://admin:${encrypted.mongodb.password}@localhost:27016
-spring.data.mongodb.database: eiffel_intelligence
-
+spring.mongodb.uri: mongodb://admin:${encrypted.mongodb.password}@localhost:27016
+spring.mongodb.database: eiffel_intelligence
 server.session.timeout: 1200
 sessions.collection.name: sessions
-
 aggregations.collection.name: aggregations
 aggregations.collection.ttl: 600
 event.object.map.collection.name: event_object_map
@@ -48,20 +41,16 @@ waitlist.resend.fixed.rate: 15000
 failed.notifications.collection.name: failed_notifications
 failed.notifications.collection.ttl: 600
 notification.retry: 3
-
 email.sender: noreply@domain.com
 email.subject: Email Subscription Notification
-
 spring.mail.host: localhost
 spring.mail.port: 1025
 spring.mail.username:
 spring.mail.password:
 spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
-
-event.repository.url: http://localhost:8084/search/
+event.repository.url: http://localhost:8094/search/
 event.repository.shallow: true
-
 ldap.enabled: false
 ldap.server.list: [{\
         "url": "",\
@@ -70,15 +59,15 @@ ldap.server.list: [{\
         "password": "",\
         "user.filter": ""\
     }]
-
 ### DEVELOPER SETTINGS
-
 spring.mongodb.embedded.version: 3.4.1
 # We remove the embedded mongodb in tests since in most of them we set up our own before Spring
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
-
 threads.core.pool.size: 100
 threads.queue.capacity: 5000
 threads.max.pool.size: 150
 scheduled.threadpool.size: 100
+# Jasypt 3.0.5 backward compat
+jasypt.encryptor.algorithm=PBEWithMD5AndDES
+jasypt.encryptor.iv-generator-classname=org.jasypt.iv.NoIvGenerator

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -86,8 +86,8 @@ services:
             aliases:
               - rabbitmq
     environment:
-      - RABBITMQ_PASSWORD=myuser
-      - RABBITMQ_USERNAME=myuser
+      - RABBITMQ_DEFAULT_PASS=myuser
+      - RABBITMQ_DEFAULT_USER=myuser
       - RABBITMQ_VHOST=/
 
   eiffel-er:

--- a/src/main/docker/env.bash
+++ b/src/main/docker/env.bash
@@ -15,9 +15,9 @@ export MONSTACHE_PORT=8086
 
 
 export MONGODB_IMAGE="mongo:latest"
-export RABBITMQ_IMAGE="bitnamilegacy/rabbitmq:3.8-debian-11"
+export RABBITMQ_IMAGE="rabbitmq:3.13-management"
 export EIFFEL_ER_IMAGE="eiffelericsson/eiffel-er:2.0.37"
-export JENKINS_IMAGE="bitnamilegacy/jenkins:2.164.3-r9"
+export JENKINS_IMAGE="jenkins/jenkins:2.361.4-lts-jdk17"
 export MAILSERVER_IMAGE="mailhog/mailhog"
 export EI_BACKEND_IMAGE="eiffelericsson/eiffel-intelligence-backend:1.0.1"
 export ELASTICSEARCH_IMAGE="docker.elastic.co/elasticsearch/elasticsearch:6.2.4"

--- a/src/main/docker/jenkins/security.groovy
+++ b/src/main/docker/jenkins/security.groovy
@@ -1,16 +1,28 @@
 #!groovy
-// Add the user admin explicitly to jenkins
-// Strategy is set to give full access to logged in user
+// Jenkins init script for CI test container.
+// Sets up admin user and permissive security for automated test execution.
 
 import jenkins.model.*
 import hudson.security.*
 
 def instance = Jenkins.getInstance()
 
+// Create admin user
 def hudsonRealm = new HudsonPrivateSecurityRealm(false)
 hudsonRealm.createAccount("admin", "admin")
 instance.setSecurityRealm(hudsonRealm)
 
-def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
-instance.setAuthorizationStrategy(strategy)
+// Allow all authenticated users full control.
+// Using UNSECURED strategy for test container — all API calls are permitted
+// without additional authorization checks. This matches the behavior of the
+// original Bitnami Jenkins 2.164.3 image used prior to the Tomcat 11 uplift.
+instance.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED)
+
+// Disable CSRF crumb requirement for API calls.
+// eiffel-commons JenkinsManager does not preserve HTTP session cookies
+// between crumb-fetch and API calls. Jenkins 2.x+ ties crumbs to sessions,
+// causing 403 on job creation. Since this is a disposable CI test container,
+// CSRF protection is not needed.
+instance.setCrumbIssuer(null)
+
 instance.save()

--- a/src/main/java/com/ericsson/ei/EndpointSecurity.java
+++ b/src/main/java/com/ericsson/ei/EndpointSecurity.java
@@ -17,21 +17,22 @@
 
 package com.ericsson.ei;
 
-import org.apache.tomcat.util.codec.binary.Base64;
-import org.apache.tomcat.util.codec.binary.StringUtils;
+import java.util.Base64;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 
 import com.ericsson.ei.encryption.EncryptionUtils;
 import com.ericsson.ei.encryption.Encryptor;
@@ -39,7 +40,7 @@ import com.ericsson.ei.exception.AbortExecutionException;
 
 @Configuration
 @EnableWebSecurity
-public class EndpointSecurity extends WebSecurityConfigurerAdapter {
+public class EndpointSecurity {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EndpointSecurity.class);
 
@@ -52,7 +53,7 @@ public class EndpointSecurity extends WebSecurityConfigurerAdapter {
     @Autowired
     private Encryptor encryptor;;
 
-    @Override
+    @Autowired
     public void configure(AuthenticationManagerBuilder auth) throws Exception {
         if (ldapEnabled && !ldapServerList.isEmpty()) {
             JSONArray serverList = new JSONArray(ldapServerList);
@@ -60,19 +61,36 @@ public class EndpointSecurity extends WebSecurityConfigurerAdapter {
         }
     }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         if (ldapEnabled) {
             LOGGER.info("LDAP security configuration is enabled");
-            configureRequestAuthorization(http);
-            configureSession(http);
-            configureLogout(http);
-            configureBasicAuth(http);
-            disableCSRF(http);
+            http
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/authentication/*").authenticated()
+                    .requestMatchers(HttpMethod.POST, "/subscriptions").authenticated()
+                    .requestMatchers(HttpMethod.PUT, "/subscriptions").authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/subscriptions").authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/subscriptions/*").authenticated()
+                    .anyRequest().permitAll()
+                )
+                .sessionManagement(session -> session
+                    .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                )
+                .logout(logout -> logout
+                    .logoutUrl("/authentication/logout")
+                    .logoutSuccessUrl("/")
+                    .deleteCookies("SESSION")
+                    .invalidateHttpSession(true)
+                )
+                .httpBasic(basic -> {})
+                .csrf(csrf -> csrf.disable());
         } else {
             LOGGER.info("LDAP security configuration is disabled");
-            disableCSRF(http);
+            http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         }
+        return http.build();
     }
 
     private void addLDAPServersFromList(JSONArray serverList, AuthenticationManagerBuilder auth) throws Exception {
@@ -110,51 +128,7 @@ public class EndpointSecurity extends WebSecurityConfigurerAdapter {
         return encryptor.decrypt(inputEncryptedPassword);
     }
 
-    private void configureRequestAuthorization(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-            .antMatchers("/authentication/*")
-            .authenticated()
-            .antMatchers(HttpMethod.POST, "/subscriptions")
-            .authenticated()
-            .antMatchers(HttpMethod.PUT, "/subscriptions")
-            .authenticated()
-            .antMatchers(HttpMethod.DELETE, "/subscriptions")
-            .authenticated()
-            .antMatchers(HttpMethod.DELETE, "/subscriptions/*")
-            .authenticated()
-            .anyRequest()
-            .permitAll();
-    }
-
-    private void configureSession(HttpSecurity http) throws Exception {
-        http.sessionManagement()
-            .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
-    }
-
-    private void configureLogout(HttpSecurity http) throws Exception {
-        http.logout()
-            .logoutUrl("/authentication/logout")
-            .logoutSuccessUrl("/")
-            .deleteCookies("SESSION")
-            .invalidateHttpSession(true);
-    }
-
-    private void configureBasicAuth(HttpSecurity http) throws Exception {
-        http.httpBasic();
-    }
-
-    private void disableCSRF(HttpSecurity http) throws Exception {
-        http.csrf()
-            // The application uses non-browser clients. Yes, there is swagger interface,
-            // but is's used only for testing/tuning.
-            //
-            // From https://docs.spring.io/spring-security/reference/features/exploits/csrf.html
-            // "If you are creating a service that is used only by non-browser clients,
-            //  you likely want to disable CSRF protection."
-            .disable();
-    }
-
     private String decodeBase64(String password) {
-        return StringUtils.newStringUtf8(Base64.decodeBase64(password));
+        return new String(Base64.getDecoder().decode(password), java.nio.charset.StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/ericsson/ei/config/ConfigurationLogger.java
+++ b/src/main/java/com/ericsson/ei/config/ConfigurationLogger.java
@@ -78,8 +78,8 @@ public class ConfigurationLogger implements ApplicationListener<ApplicationPrepa
     private String getPropertyValueAndCheckForSpecialCases(String propertyName) {
         final String maskedProperty = "*****";
         switch (propertyName) {
-        case "spring.data.mongodb.uri":
-            final String unsafeUri = environment.getProperty("spring.data.mongodb.uri");
+        case "spring.mongodb.uri":
+            final String unsafeUri = environment.getProperty("spring.mongodb.uri");
             final String safeUri = MongoUri.getUriWithHiddenPassword(unsafeUri);
             return safeUri;
         case "rabbitmq.password":

--- a/src/main/java/com/ericsson/ei/config/HeaderAndCookieHttpSessionIdResolver.java
+++ b/src/main/java/com/ericsson/ei/config/HeaderAndCookieHttpSessionIdResolver.java
@@ -3,8 +3,8 @@ package com.ericsson.ei.config;
 import java.util.Collections;
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.CookieSerializer.CookieValue;

--- a/src/main/java/com/ericsson/ei/config/SpringAsyncConfig.java
+++ b/src/main/java/com/ericsson/ei/config/SpringAsyncConfig.java
@@ -24,18 +24,9 @@ import java.util.concurrent.Executor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
-import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
-import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver;
-import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
-import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
-import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
-import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
-import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -72,22 +63,4 @@ public class SpringAsyncConfig implements AsyncConfigurer{
         // TODO Auto-generated method stub
         return null;
     }
-    
-    @Bean
-    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(WebEndpointsSupplier webEndpointsSupplier, ServletEndpointsSupplier servletEndpointsSupplier, ControllerEndpointsSupplier controllerEndpointsSupplier, EndpointMediaTypes endpointMediaTypes, CorsEndpointProperties corsProperties, WebEndpointProperties webEndpointProperties, Environment environment) {
-            List<ExposableEndpoint<?>> allEndpoints = new ArrayList<>();
-            Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
-            allEndpoints.addAll(webEndpoints);
-            allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
-            allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
-            String basePath = webEndpointProperties.getBasePath();
-            EndpointMapping endpointMapping = new EndpointMapping(basePath);
-            boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
-            return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes, corsProperties.toCorsConfiguration(), new EndpointLinksResolver(allEndpoints, basePath), shouldRegisterLinksMapping, null);
-        }
-
-
-    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties, Environment environment, String basePath) {
-            return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.isNotEmpty(basePath) || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
-        }
 }

--- a/src/main/java/com/ericsson/ei/config/SwaggerConfig.java
+++ b/src/main/java/com/ericsson/ei/config/SwaggerConfig.java
@@ -22,21 +22,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-import springfox.documentation.swagger.web.DocExpansion;
-import springfox.documentation.swagger.web.ModelRendering;
-import springfox.documentation.swagger.web.OperationsSorter;
-import springfox.documentation.swagger.web.TagsSorter;
-import springfox.documentation.swagger.web.UiConfiguration;
-import springfox.documentation.swagger.web.UiConfigurationBuilder;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
 
-import java.util.Collections;
+import org.springdoc.core.models.GroupedOpenApi;
 
 @Configuration
 public class SwaggerConfig {
@@ -49,49 +40,26 @@ public class SwaggerConfig {
     ParseInstanceInfoEI parseInstanceInfoEI;
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("com.ericsson.ei.controller"))
-                .paths(PathSelectors.any())
-                .build()
-                .apiInfo(metaData());
-    }
-
-        /**
-     * SwaggerUI information
-     */
-
-    @Bean
-    UiConfiguration uiConfig() {
-        return UiConfigurationBuilder.builder()
-                .deepLinking(true)
-                .displayOperationId(false)
-                .defaultModelsExpandDepth(-1)
-                .defaultModelExpandDepth(1)
-                .defaultModelRendering(ModelRendering.EXAMPLE)
-                .displayRequestDuration(false)
-                .docExpansion(DocExpansion.NONE)
-                .filter(false)
-                .maxDisplayedTags(null)
-                .operationsSorter(OperationsSorter.ALPHA)
-                .showExtensions(false)
-                .tagsSorter(TagsSorter.ALPHA)
-                .supportedSubmitMethods(UiConfiguration.Constants.DEFAULT_SUBMIT_METHODS)
-                .validatorUrl(null)
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("eiffel-intelligence")
+                .packagesToScan("com.ericsson.ei.controller")
                 .build();
     }
 
-    private ApiInfo metaData() {
-        ApiInfo apiInfo = new ApiInfo(
-                "Eiffel Intelligence REST API",
-                "A real time data aggregation and analysis solution for Eiffel events.",
-                parseInstanceInfoEI.getVersion(),
-                "Terms of service",
-                new Contact(CONTACT_NAME, CONTACT_URL, CONTACT_EMAIL),
-               "Apache License Version 2.0",
-               "https://www.apache.org/licenses/LICENSE-2.0",
-               Collections.emptyList());
-        return apiInfo;
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Eiffel Intelligence REST API")
+                        .description("A real time data aggregation and analysis solution for Eiffel events.")
+                        .version(parseInstanceInfoEI.getVersion())
+                        .contact(new Contact()
+                                .name(CONTACT_NAME)
+                                .url(CONTACT_URL)
+                                .email(CONTACT_EMAIL))
+                        .license(new License()
+                                .name("Apache License Version 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0")));
     }
 }

--- a/src/main/java/com/ericsson/ei/controller/AggregatedObjectController.java
+++ b/src/main/java/com/ericsson/ei/controller/AggregatedObjectController.java
@@ -1,8 +1,8 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import com.ericsson.ei.controller.model.QueryBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/src/main/java/com/ericsson/ei/controller/AggregatedObjectControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AggregatedObjectControllerImpl.java
@@ -15,7 +15,10 @@ package com.ericsson.ei.controller;
 
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -37,8 +40,6 @@ import com.ericsson.ei.queryservice.ProcessQueryParams;
 import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 
 /**
  * This class represents the REST GET mechanism to extract the aggregated data on the basis of the
@@ -46,7 +47,7 @@ import io.swagger.annotations.Api;
  */
 @Component
 @CrossOrigin
-@Api(tags = {"Aggregated objects"}, description = "Fetch aggregated data based on Id")
+@Tag(name = "Aggregated objects", description = "Fetch aggregated data based on Id")
 public class AggregatedObjectControllerImpl implements AggregatedObjectController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AggregatedObjectControllerImpl.class);
@@ -65,7 +66,7 @@ public class AggregatedObjectControllerImpl implements AggregatedObjectControlle
      * @return ResponseEntity
      */
     @Override
-    @ApiOperation(value = "Get a specific aggregated object", tags = { "Aggregated objects" })
+    @Operation(summary = "Get a specific aggregated object")
     public ResponseEntity<?> getAggregatedObjectById(@PathVariable final String id,
             final HttpServletRequest httpRequest) {
         ObjectMapper mapper = new ObjectMapper();
@@ -92,7 +93,7 @@ public class AggregatedObjectControllerImpl implements AggregatedObjectControlle
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Perform a freestyle query to retrieve aggregated objects", tags = { "Aggregated objects" })
+    @Operation(summary = "Perform a freestyle query to retrieve aggregated objects")
     public ResponseEntity<?> createAggregatedObjectsQuery(@RequestBody final QueryBody body,
             final HttpServletRequest httpRequest) {
         String emptyResponseContent = "[]";

--- a/src/main/java/com/ericsson/ei/controller/AuthenticationController.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthenticationController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/ericsson/ei/controller/AuthenticationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/AuthenticationControllerImpl.java
@@ -16,7 +16,9 @@ authentication   Copyright 2018 Ericsson AB.
 */
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -30,16 +32,14 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 
 import com.ericsson.ei.utils.ResponseMessage;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 
 /**
  * Endpoint /authentication/login should be secured if LDAP is enabled.
  * Endpoint /authentication should never be secured.
  */
+@Tag(name = "Authentication", description = "Authentication queries")
 @Component
 @CrossOrigin
-@Api(tags = {"Authentication"}, description = "Authentication queries")
 public class AuthenticationControllerImpl implements AuthenticationController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationControllerImpl.class);
@@ -49,8 +49,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Check if security is enabled", tags = { "Authentication" },
-            response = String.class)
+    @Operation(summary = "Check if security is enabled")
     public ResponseEntity<?> getAuthentication(final HttpServletRequest httpRequest) {
         try {
             return new ResponseEntity<>(new JSONObject().put("security", ldapEnabled).toString(),
@@ -65,8 +64,7 @@ public class AuthenticationControllerImpl implements AuthenticationController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Get login of current user", tags = { "Authentication" }, response =
-            String.class)
+    @Operation(summary = "Get login of current user")
     public ResponseEntity<?> getAuthenticationLogin(final HttpServletRequest httpRequest) {
         try {
             String currentUser = SecurityContextHolder.getContext().getAuthentication().getName();

--- a/src/main/java/com/ericsson/ei/controller/EIHomeController.java
+++ b/src/main/java/com/ericsson/ei/controller/EIHomeController.java
@@ -16,8 +16,7 @@
 */
 package com.ericsson.ei.controller;
 
-import io.swagger.annotations.ApiOperation;
-import springfox.documentation.annotations.ApiIgnore;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -28,10 +27,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 *
 */
 @Controller
-@ApiIgnore
+@Hidden
 public class EIHomeController {
-
-    @ApiOperation(value="", hidden = true)
     @RequestMapping(value = "/", method = RequestMethod.GET)
     public String home() {
         return "redirect:/swagger-ui/index.html";

--- a/src/main/java/com/ericsson/ei/controller/FailedNotificationController.java
+++ b/src/main/java/com/ericsson/ei/controller/FailedNotificationController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/ericsson/ei/controller/FailedNotificationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/FailedNotificationControllerImpl.java
@@ -16,7 +16,9 @@ package com.ericsson.ei.controller;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -33,15 +35,13 @@ import com.ericsson.ei.controller.model.QueryResponse;
 import com.ericsson.ei.queryservice.ProcessFailedNotification;
 import com.ericsson.ei.utils.ResponseMessage;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 
 /**
  * This class contains logic for retrieving failed notifications for the given subscription.
  */
+@Tag(name = "Failed notifications", description = "Fetch failed notifications of a subscription")
 @Component
 @CrossOrigin
-@Api(tags = {"Failed notifications"}, description = "Fetch failed notifications of a subscription")
 public class FailedNotificationControllerImpl implements FailedNotificationController {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(
@@ -57,8 +57,7 @@ public class FailedNotificationControllerImpl implements FailedNotificationContr
      * @param subscriptionNames
      */
     @Override
-    @ApiOperation(value = "Retrieve failed notifications", tags = { "Failed notifications" },
-            response = QueryResponse.class)
+    @Operation(summary = "Retrieve failed notifications")
     public ResponseEntity<?> getFailedNotifications(
             @RequestParam(value = "subscriptionNames", required = true) final String subscriptionNames,
             final HttpServletRequest httpRequest) {

--- a/src/main/java/com/ericsson/ei/controller/InformationController.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/InformationControllerImpl.java
@@ -16,10 +16,10 @@ package com.ericsson.ei.controller;
 import com.ericsson.ei.controller.model.ParseInstanceInfoEI;
 import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,9 +29,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+@Tag(name = "Information", description = "Information about Eiffel Intelligence backend")
 @Component
 @CrossOrigin
-@Api(tags = {"Information"}, description = "Information about Eiffel Intelligence backend")
 public class InformationControllerImpl implements InformationController {
     private static final Logger LOGGER = LoggerFactory.getLogger(InformationControllerImpl.class);
 
@@ -40,8 +40,7 @@ public class InformationControllerImpl implements InformationController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Shows information about Eiffel Intelligence back-end", tags = {
-            "Information"})
+    @Operation(summary = "Shows information about Eiffel Intelligence back-end")
     public ResponseEntity<?> getInformation(final HttpServletRequest httpRequest) {
         try {
             String info = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(instanceInfo);

--- a/src/main/java/com/ericsson/ei/controller/RuleController.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleControllerImpl.java
@@ -16,7 +16,9 @@
 */
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -34,12 +36,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 
+@Tag(name = "Rules", description = "Active rules queries")
 @Component
 @CrossOrigin
-@Api(tags = {"Rules"}, description = "Active rules queries")
 public class RuleControllerImpl implements RuleController{
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RuleControllerImpl.class);
@@ -52,8 +52,7 @@ public class RuleControllerImpl implements RuleController{
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Get the active rules from Eiffel Intelligence", tags = {"Rules"},
-            response = String.class)
+    @Operation(summary = "Get the active rules from Eiffel Intelligence")
     public ResponseEntity<?> getRules(final HttpServletRequest httpRequest) {
         JsonNode rulesContent = rulesHandler.getRulesContent();
         ObjectMapper objectmapper = new ObjectMapper();

--- a/src/main/java/com/ericsson/ei/controller/RuleTestController.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleTestController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import com.ericsson.ei.controller.model.RuleCheckBody;
 import com.ericsson.ei.controller.model.RulesCheckBody;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +35,7 @@ public interface RuleTestController {
      */
     @RequestMapping(value = "/run-single-rule", method = RequestMethod.POST)
     public ResponseEntity<?> createRuleTestRunSingleRule(
-        @javax.validation.Valid
+        @jakarta.validation.Valid
         @org.springframework.web.bind.annotation.RequestBody
         RuleCheckBody ruleCheckBody, HttpServletRequest httpRequest);
 
@@ -45,7 +45,7 @@ public interface RuleTestController {
      */
     @RequestMapping(value = "/run-full-aggregation", method = RequestMethod.POST)
     public ResponseEntity<?> createRuleTestRunFullAggregation(
-        @javax.validation.Valid
+        @jakarta.validation.Valid
         @org.springframework.web.bind.annotation.RequestBody
         RulesCheckBody rulesCheckBody, HttpServletRequest httpRequest);
 

--- a/src/main/java/com/ericsson/ei/controller/RuleTestControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/RuleTestControllerImpl.java
@@ -2,7 +2,9 @@ package com.ericsson.ei.controller;
 
 import java.io.IOException;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -25,14 +27,11 @@ import com.ericsson.ei.rules.IRuleTestService;
 import com.ericsson.ei.utils.ResponseMessage;
 
 import io.netty.util.internal.StringUtil;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.Api;
 import lombok.Setter;
 
+@Tag(name = "Rule-test", description = "Test rules on Eiffel events")
 @Component
 @CrossOrigin
-@Api(tags = {"Rule-test"}, description = "Test rules on Eiffel events")
 public class RuleTestControllerImpl implements RuleTestController {
     private static final Logger LOGGER = LoggerFactory.getLogger(RuleTestControllerImpl.class);
 
@@ -59,10 +58,9 @@ public class RuleTestControllerImpl implements RuleTestController {
      */
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Execute rule on one Eiffel event", tags = {"Rule-test"}, response
-            = String.class)
+    @Operation(summary = "Execute rule on one Eiffel event")
     public ResponseEntity<?> createRuleTestRunSingleRule (
-            @ApiParam(value = "JSON object", required = true) @RequestBody RuleCheckBody body, final HttpServletRequest httpRequest) {
+            @RequestBody RuleCheckBody body, final HttpServletRequest httpRequest) {
         JSONObject rule = new JSONObject(body.getRule().getAdditionalProperties());
         JSONObject event = new JSONObject(body.getEvent().getAdditionalProperties());
 
@@ -81,10 +79,9 @@ public class RuleTestControllerImpl implements RuleTestController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Execute a list of rules on a list of Eiffel events. Returns the "
-            + "aggregated object(s)", tags = {"Rule-test"}, response = String.class)
+    @Operation(summary = "Execute a list of rules on a list of Eiffel events")
     public ResponseEntity<?> createRuleTestRunFullAggregation(
-            @ApiParam(value = "Object that include list of rules and list of Eiffel events", required = true) @RequestBody RulesCheckBody body,
+            @RequestBody RulesCheckBody body,
             final HttpServletRequest httpRequest) {
         if (testEnabled) {
             String aggregatedObject = StringUtil.EMPTY_STRING;
@@ -125,8 +122,7 @@ public class RuleTestControllerImpl implements RuleTestController {
     }
 
     @Override
-    @ApiOperation(value = "Check if rules test service is enabled", tags = {"Rule-test"},
-            response = String.class)
+    @Operation(summary = "Check if rules test service is enabled")
     public ResponseEntity<?> getRuleTest(HttpServletRequest httpRequest) {
         LOGGER.debug("Getting Enabled Status of Rules Test Service");
         try {

--- a/src/main/java/com/ericsson/ei/controller/StatusController.java
+++ b/src/main/java/com/ericsson/ei/controller/StatusController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/ericsson/ei/controller/StatusControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/StatusControllerImpl.java
@@ -16,7 +16,9 @@
 */
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,16 +33,14 @@ import com.ericsson.ei.utils.ResponseMessage;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 
 /**
  * Endpoint /status should display EI back-end status and services Eiffel Intelligence is dependent
  * on.
  */
+@Tag(name = "Status", description = "Information of EI and its dependencies")
 @Component
 @CrossOrigin
-@Api(tags = {"Status"}, description = "Information of EI and its dependencies")
 public class StatusControllerImpl implements StatusController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StatusControllerImpl.class);
@@ -52,7 +52,7 @@ public class StatusControllerImpl implements StatusController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Check back-end status", tags = { "Status" }, response = String.class)
+    @Operation(summary = "Check back-end status")
     public ResponseEntity<?> getStatus(HttpServletRequest httpRequest) {
         try {
             final JsonNode status = statusHandler.getCurrentStatus();

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionController.java
@@ -2,8 +2,8 @@
 package com.ericsson.ei.controller;
 
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/SubscriptionControllerImpl.java
@@ -25,7 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,12 +50,10 @@ import com.ericsson.ei.services.ISubscriptionService;
 import com.ericsson.ei.subscription.SubscriptionValidator;
 import com.ericsson.ei.utils.ResponseMessage;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 
+@Tag(name = "Subscriptions", description = "Subscription handling requests")
 @Component
 @CrossOrigin
-@Api(tags = {"Subscriptions"}, description = "Subscription handling requests")
 public class SubscriptionControllerImpl implements SubscriptionController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionControllerImpl.class);
@@ -70,7 +70,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Create subscription(s)", tags = {"Subscriptions"})
+    @Operation(summary = "Create subscription(s)")
     public ResponseEntity<?> createSubscription(@RequestBody List<Subscription> subscriptions, final HttpServletRequest httpRequest) {
         Map<String, String> errorMap = new HashMap<>();
         String user = (ldapEnabled) ? HttpSessionConfig.getCurrentUser() : "";
@@ -100,7 +100,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Update existing subscription(s)", tags = {"Subscriptions"})
+    @Operation(summary = "Update existing subscription(s)")
     public ResponseEntity<?> updateSubscriptions(@RequestBody List<Subscription> subscriptions, final HttpServletRequest httpRequest) {
         Map<String, String> errorMap = new HashMap<>();
         String user = (ldapEnabled) ? HttpSessionConfig.getCurrentUser() : "";
@@ -129,7 +129,7 @@ public class SubscriptionControllerImpl implements SubscriptionController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Retrieve all or specific subscriptions", tags = {"Subscriptions"})
+    @Operation(summary = "Retrieve all or specific subscriptions")
     public ResponseEntity<?> getSubscriptions(@RequestParam(required = false) String subscriptionNames,
             final HttpServletRequest httpRequest) {
         String queryString = httpRequest.getQueryString();
@@ -150,21 +150,21 @@ public class SubscriptionControllerImpl implements SubscriptionController {
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Retrieve a single subscription", tags = {"Subscriptions"})
+    @Operation(summary = "Retrieve a single subscription")
     public ResponseEntity<?> getSubscriptionByName(@PathVariable String subscriptionName, final HttpServletRequest httpRequest) {
         return getSingleSubscription(subscriptionName);
     }
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Remove subscription(s)", tags = {"Subscriptions"})
+    @Operation(summary = "Remove subscription(s)")
     public ResponseEntity<?> deleteSubscriptions(@RequestParam String subscriptionNames, final HttpServletRequest httpRequest) {
         return deleteListedSubscriptions(subscriptionNames);
     }
 
     @Override
     @CrossOrigin
-    @ApiOperation(value = "Remove a single subscription", tags = {"Subscriptions"})
+    @Operation(summary = "Remove a single subscription")
     public ResponseEntity<?> deleteSubscriptionByName(@PathVariable String subscriptionName, final HttpServletRequest httpRequest) {
         return deleteSingleSubscription(subscriptionName);
     }

--- a/src/main/java/com/ericsson/ei/controller/TemplateController.java
+++ b/src/main/java/com/ericsson/ei/controller/TemplateController.java
@@ -1,7 +1,7 @@
 
 package com.ericsson.ei.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/ericsson/ei/controller/TemplateControllerImpl.java
+++ b/src/main/java/com/ericsson/ei/controller/TemplateControllerImpl.java
@@ -18,10 +18,10 @@ package com.ericsson.ei.controller;
 
 import java.io.InputStream;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.Api;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -33,16 +33,16 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 
 import com.ericsson.ei.utils.ResponseMessage;
 
+@Tag(name = "Templates", description = "Templates of rules, Eiffel events and subscriptions")
 @Component
 @CrossOrigin
-@Api(tags = {"Templates"}, description = "Templates of rules, Eiffel events and subscriptions")
 public class TemplateControllerImpl implements TemplateController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(
             TemplateControllerImpl.class);
 
     @Override
-    @ApiOperation(value = "Retrieve REST endpoints for downloading templates", tags = {"Templates"})
+    @Operation(summary = "Retrieve REST endpoints for downloading templates")
     public ResponseEntity<?> getTemplates(final HttpServletRequest httpRequest) {
         try {
             JSONObject response = new JSONObject();
@@ -59,7 +59,7 @@ public class TemplateControllerImpl implements TemplateController {
     }
 
     @Override
-    @ApiOperation(value = "Download subscription template", tags = {"Templates"})
+    @Operation(summary = "Download subscription template")
     public ResponseEntity<?> getTemplatesSubscriptions(final HttpServletRequest httpRequest) {
         try {
             InputStream is = getClass().getResourceAsStream(
@@ -79,7 +79,7 @@ public class TemplateControllerImpl implements TemplateController {
     }
 
     @Override
-    @ApiOperation(value = "Download rules template", tags = {"Templates"})
+    @Operation(summary = "Download rules template")
     public ResponseEntity<?> getTemplatesRules(final HttpServletRequest httpRequest) {
         try {
             InputStream is = getClass().getResourceAsStream(
@@ -99,7 +99,7 @@ public class TemplateControllerImpl implements TemplateController {
     }
 
     @Override
-    @ApiOperation(value = "Download Eiffel events template", tags = {"Templates"})
+    @Operation(summary = "Download Eiffel events template")
     public ResponseEntity<?> getTemplatesEvents(final HttpServletRequest httpRequest) {
         try {
             InputStream is = getClass().getResourceAsStream(

--- a/src/main/java/com/ericsson/ei/controller/model/Condition.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Condition.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/Criteria.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Criteria.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/Event.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Event.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/GetSubscriptionResponse.java
+++ b/src/main/java/com/ericsson/ei/controller/model/GetSubscriptionResponse.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/NotificationMessageKeyValue.java
+++ b/src/main/java/com/ericsson/ei/controller/model/NotificationMessageKeyValue.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/Options.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Options.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ParseInstanceInfoEI.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.json.JSONArray;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -150,12 +150,12 @@ public class ParseInstanceInfoEI {
         private String uri;
 
         @Getter
-        @Value("${spring.data.mongodb.database}")
+        @Value("${spring.mongodb.database}")
         private String database;
 
         @PostConstruct
         public void init() throws IOException {
-            final String unsafeUri = environment.getProperty("spring.data.mongodb.uri");
+            final String unsafeUri = environment.getProperty("spring.mongodb.uri");
             uri = MongoUri.getUriWithHiddenPassword(unsafeUri);
         }
 

--- a/src/main/java/com/ericsson/ei/controller/model/QueryBody.java
+++ b/src/main/java/com/ericsson/ei/controller/model/QueryBody.java
@@ -3,8 +3,8 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/QueryResponse.java
+++ b/src/main/java/com/ericsson/ei/controller/model/QueryResponse.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/QueryResponseEntity.java
+++ b/src/main/java/com/ericsson/ei/controller/model/QueryResponseEntity.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/Requirement.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Requirement.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/ResponseEntity.java
+++ b/src/main/java/com/ericsson/ei/controller/model/ResponseEntity.java
@@ -4,7 +4,7 @@ package com.ericsson.ei.controller.model;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;

--- a/src/main/java/com/ericsson/ei/controller/model/Rule.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Rule.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/RuleCheckBody.java
+++ b/src/main/java/com/ericsson/ei/controller/model/RuleCheckBody.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/RulesCheckBody.java
+++ b/src/main/java/com/ericsson/ei/controller/model/RulesCheckBody.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/Subscription.java
+++ b/src/main/java/com/ericsson/ei/controller/model/Subscription.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/controller/model/SubscriptionResponse.java
+++ b/src/main/java/com/ericsson/ei/controller/model/SubscriptionResponse.java
@@ -3,7 +3,7 @@ package com.ericsson.ei.controller.model;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/src/main/java/com/ericsson/ei/encryption/Encryptor.java
+++ b/src/main/java/com/ericsson/ei/encryption/Encryptor.java
@@ -17,7 +17,7 @@
 
 package com.ericsson.ei.encryption;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;

--- a/src/main/java/com/ericsson/ei/handlers/EventToObjectMapHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/EventToObjectMapHandler.java
@@ -19,7 +19,7 @@ package com.ericsson.ei.handlers;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
@@ -56,7 +56,7 @@ public class EventToObjectMapHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(EventToObjectMapHandler.class);
 
     @Value("${event.object.map.collection.name}") private String collectionName;
-    @Value("${spring.data.mongodb.database}") private String databaseName;
+    @Value("${spring.mongodb.database}") private String databaseName;
     
 
     private final String listPropertyName = "objects";

--- a/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/ObjectHandler.java
@@ -20,7 +20,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
@@ -63,7 +63,7 @@ public class ObjectHandler {
 
     @Getter
     @Setter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String databaseName;
 
     @Getter

--- a/src/main/java/com/ericsson/ei/handlers/RMQHandler.java
+++ b/src/main/java/com/ericsson/ei/handlers/RMQHandler.java
@@ -84,7 +84,7 @@ public class RMQHandler {
 
     @Getter
     @Setter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String dataBaseName;
 
     @Getter
@@ -119,7 +119,7 @@ public class RMQHandler {
             }
         }
 
-        cachingConnectionFactory.setPublisherConfirms(true);
+        cachingConnectionFactory.setPublisherConfirmType(org.springframework.amqp.rabbit.connection.CachingConnectionFactory.ConfirmType.CORRELATED);
         cachingConnectionFactory.setPublisherReturns(true);
 
         // This will disable connectionFactories auto recovery and use Spring AMQP auto

--- a/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoDBHandler.java
@@ -18,8 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
 import org.apache.commons.lang3.StringUtils;
 import org.bson.Document;
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.mongodb.autoconfigure.MongoProperties;
 import org.springframework.stereotype.Component;
 
 import com.ericsson.ei.exception.AbortExecutionException;
@@ -72,7 +72,7 @@ public class MongoDBHandler {
     @JsonIgnore
     private MongoClient mongoClient;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String databaseName;
 
     // TODO establish connection automatically when Spring instantiate this
@@ -346,7 +346,7 @@ public class MongoDBHandler {
     private void createMongoClient() throws AbortExecutionException {
         if (StringUtils.isBlank(mongoProperties.getUri())) {
             throw new MongoConfigurationException(
-                    "Failure to create MongoClient, missing config for spring.data.mongodb.uri:");
+                    "Failure to create MongoClient, missing config for spring.mongodb.uri:");
         }
         mongoClient = MongoClients.create(mongoProperties.getUri());
     }

--- a/src/main/java/com/ericsson/ei/mongo/MongoUri.java
+++ b/src/main/java/com/ericsson/ei/mongo/MongoUri.java
@@ -100,7 +100,7 @@ public class MongoUri {
      */
     private static void uriIsSet(String uri) {
         if (StringUtils.isBlank(uri)) {
-            throw new MongoConfigurationException("No configuration for spring.data.mongodb.uri was found");
+            throw new MongoConfigurationException("No configuration for spring.mongodb.uri was found");
         }
     }
 

--- a/src/main/java/com/ericsson/ei/notifications/EmailSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/EmailSender.java
@@ -19,8 +19,8 @@ package com.ericsson.ei.notifications;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
+++ b/src/main/java/com/ericsson/ei/notifications/HttpRequestSender.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
@@ -45,7 +45,7 @@ public class HttpRequestSender {
     @Autowired
     public HttpRequestSender(RestTemplateBuilder builder, @Value("${notification.httpRequest.timeout:5000}") Duration timeOut) {
         timeOut = timeOut == null ? Duration.ofMillis(5000) : timeOut;
-        rest = builder.setReadTimeout(timeOut).setConnectTimeout(timeOut).build();
+        rest = builder.connectTimeout(timeOut).readTimeout(timeOut).build();
     }
 
     /**
@@ -77,7 +77,7 @@ public class HttpRequestSender {
             throw e;
         }
 
-        HttpStatus status = response.getStatusCode();
+        HttpStatus status = (HttpStatus) response.getStatusCode();
         JsonNode body = response.getBody();
         boolean httpStatusSuccess = status == HttpStatus.OK || status == HttpStatus.ACCEPTED
                 || status == HttpStatus.CREATED;

--- a/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
+++ b/src/main/java/com/ericsson/ei/notifications/InformSubscriber.java
@@ -18,8 +18,8 @@ package com.ericsson.ei.notifications;
 
 import java.text.ParseException;
 
-import javax.annotation.PostConstruct;
-import javax.mail.internet.MimeMessage;
+import jakarta.annotation.PostConstruct;
+import jakarta.mail.internet.MimeMessage;
 
 import com.ericsson.ei.mongo.MongoConstants;
 import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
@@ -71,7 +71,7 @@ public class InformSubscriber {
     private String failedNotificationCollectionName;
 
     @Getter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Getter

--- a/src/main/java/com/ericsson/ei/queryservice/ProcessAggregatedObject.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessAggregatedObject.java
@@ -42,7 +42,7 @@ public class ProcessAggregatedObject {
     @Value("${aggregations.collection.name}")
     private String aggregationCollectionName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String aggregationDataBaseName;
 
     @Autowired

--- a/src/main/java/com/ericsson/ei/queryservice/ProcessFailedNotification.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessFailedNotification.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,7 @@ public class ProcessFailedNotification {
     @Value("${failed.notifications.collection.name}")
     private String failedNotificationCollectionName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Autowired

--- a/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
+++ b/src/main/java/com/ericsson/ei/queryservice/ProcessQueryParams.java
@@ -41,7 +41,7 @@ public class ProcessQueryParams {
     @Value("${aggregations.collection.name}")
     private String aggregationCollectionName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String databaseName;
 
 

--- a/src/main/java/com/ericsson/ei/repository/SubscriptionRepository.java
+++ b/src/main/java/com/ericsson/ei/repository/SubscriptionRepository.java
@@ -36,7 +36,7 @@ public class SubscriptionRepository implements ISubscriptionRepository {
     @Value("${subscriptions.collection.name}")
     private String collectionName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String dataBaseName;
 
     @Autowired

--- a/src/main/java/com/ericsson/ei/rules/RulesHandler.java
+++ b/src/main/java/com/ericsson/ei/rules/RulesHandler.java
@@ -24,7 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;

--- a/src/main/java/com/ericsson/ei/services/SubscriptionService.java
+++ b/src/main/java/com/ericsson/ei/services/SubscriptionService.java
@@ -52,7 +52,7 @@ public class SubscriptionService implements ISubscriptionService {
     @Value("${spring.application.name}")
     private String springApplicationName;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String dataBaseName;
 
     @Value("${subscriptions.repeat.handler.collection.name}")

--- a/src/main/java/com/ericsson/ei/subscription/RunSubscription.java
+++ b/src/main/java/com/ericsson/ei/subscription/RunSubscription.java
@@ -50,7 +50,7 @@ public class RunSubscription {
     private SubscriptionRepeatDbHandler subscriptionRepeatDbHandler;
     
     @Getter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     public String dataBaseName;
 
     /**

--- a/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
+++ b/src/main/java/com/ericsson/ei/subscription/SubscriptionHandler.java
@@ -53,7 +53,7 @@ public class SubscriptionHandler {
     private String subscriptionCollectionName;
 
     @Getter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Autowired

--- a/src/main/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandler.java
+++ b/src/main/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandler.java
@@ -51,7 +51,7 @@ public class SubscriptionRepeatDbHandler {
 
     @Getter
     @Setter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     public String dataBaseName;
     @Getter
     @Setter

--- a/src/main/java/com/ericsson/ei/utils/MongoDBMonitorThread.java
+++ b/src/main/java/com/ericsson/ei/utils/MongoDBMonitorThread.java
@@ -36,7 +36,7 @@ public class MongoDBMonitorThread extends Thread {
 
 	private static boolean isMongoDBConnected = false;
 
-	@Value("${spring.data.mongodb.database}")
+	@Value("${spring.mongodb.database}")
 	private String dataBaseName;
 
 	@Override

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListStorageHandler.java
@@ -40,7 +40,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class WaitListStorageHandler {
@@ -51,7 +51,7 @@ public class WaitListStorageHandler {
     private String waitlistCollectionName;
 
     @Getter
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String databaseName;
 
     @Getter

--- a/src/main/java/com/ericsson/ei/waitlist/WaitListWorker.java
+++ b/src/main/java/com/ericsson/ei/waitlist/WaitListWorker.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 
 import com.ericsson.ei.mongo.MongoConstants;
 import org.slf4j.Logger;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,8 +28,8 @@ rabbitmq.waitlist.queue.suffix: waitList
 
 bindingkeys.collection.name: binding_keys
 
-spring.data.mongodb.uri: mongodb://localhost:27017
-spring.data.mongodb.database: eiffel_intelligence
+spring.mongodb.uri: mongodb://localhost:27017
+spring.mongodb.database: eiffel_intelligence
 
 server.session.timeout: 1200
 sessions.collection.name: sessions

--- a/src/test/java/com/ericsson/ei/controller/ControllerTestBaseClass.java
+++ b/src/test/java/com/ericsson/ei/controller/ControllerTestBaseClass.java
@@ -4,14 +4,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.ericsson.ei.EndpointSecurity;
+
 @AutoConfigureMockMvc
+@Import(EndpointSecurity.class)
 public class ControllerTestBaseClass {
 
     @Autowired

--- a/src/test/java/com/ericsson/ei/controller/TestAuthenticationControllerImpl.java
+++ b/src/test/java/com/ericsson/ei/controller/TestAuthenticationControllerImpl.java
@@ -29,7 +29,7 @@ import com.ericsson.ei.App;
 import com.ericsson.ei.utils.TestContextInitializer;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestAuthControllerImpl",
+        "spring.mongodb.database: TestAuthControllerImpl",
         "failed.notifications.collection.name: TestAuthControllerImpl-failedNotifications",
         "rabbitmq.exchange.name: TestAuthControllerImpl-exchange",
         "rabbitmq.queue.suffix: TestAuthControllerImpl" })

--- a/src/test/java/com/ericsson/ei/controller/TestInformationControllerImpl.java
+++ b/src/test/java/com/ericsson/ei/controller/TestInformationControllerImpl.java
@@ -15,9 +15,9 @@ package com.ericsson.ei.controller;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootContextLoader;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -28,7 +28,7 @@ import com.ericsson.ei.encryption.Encryptor;
 import com.ericsson.ei.utils.TestContextInitializer;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestInformationControllerImpl",
+        "spring.mongodb.database: TestInformationControllerImpl",
         "failed.notifications.collection.name: TestInformationControllerImpl-failedNotifications",
         "rabbitmq.exchange.name: TestInformationControllerImpl-exchange",
         "rabbitmq.queue.suffix: TestInformationControllerImpl" })
@@ -37,13 +37,13 @@ import com.ericsson.ei.utils.TestContextInitializer;
 @WebMvcTest(value = InformationController.class)
 public class TestInformationControllerImpl extends ControllerTestBaseClass {
 
-    @MockBean
+    @MockitoBean
     private ParseInstanceInfoEI istanceInfo;
 
-    @MockBean
+    @MockitoBean
     private InformationController infoController;
     
-    @MockBean
+    @MockitoBean
     private Encryptor encryptor;
 
     @Test

--- a/src/test/java/com/ericsson/ei/controller/TestQueryControllerImpl.java
+++ b/src/test/java/com/ericsson/ei/controller/TestQueryControllerImpl.java
@@ -28,10 +28,10 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -42,7 +42,7 @@ import com.ericsson.ei.queryservice.ProcessQueryParams;
 import com.ericsson.ei.utils.TestContextInitializer;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestQueryControllerImpl",
+        "spring.mongodb.database: TestQueryControllerImpl",
         "failed.notifications.collection.name: TestQueryControllerImpl-failedNotifications",
         "rabbitmq.exchange.name: TestQueryControllerImpl-exchange",
         "rabbitmq.queue.suffix: TestQueryControllerImpl" })
@@ -56,7 +56,7 @@ public class TestQueryControllerImpl extends ControllerTestBaseClass {
     private static String INPUT;
     private final String QUERY_ENDPOINT = "/query";
 
-    @MockBean
+    @MockitoBean
     private ProcessQueryParams unitUnderTest;
 
     @Before

--- a/src/test/java/com/ericsson/ei/controller/TestTemplateControllerImpl.java
+++ b/src/test/java/com/ericsson/ei/controller/TestTemplateControllerImpl.java
@@ -29,7 +29,7 @@ import com.ericsson.ei.App;
 import com.ericsson.ei.utils.TestContextInitializer;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestTemplatesControllerImpl",
+        "spring.mongodb.database: TestTemplatesControllerImpl",
         "failed.notifications.collection.name: TestTemplatesControllerImpl-failedNotifications",
         "rabbitmq.exchange.name: TestTemplatesControllerImpl-exchange",
         "rabbitmq.queue.suffix: TestTemplatesControllerImpl" })

--- a/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/erqueryservice/test/ERQueryServiceTest.java
@@ -52,7 +52,7 @@ import com.google.common.io.CharStreams;
 
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: ERQueryServiceTest",
+        "spring.mongodb.database: ERQueryServiceTest",
         "failed.notifications.collection.name: ERQueryServiceTest-failedNotifications",
         "rabbitmq.exchange.name: ERQueryServiceTest-exchange",
         "rabbitmq.queue.suffix: ERQueryServiceTest",

--- a/src/test/java/com/ericsson/ei/flowtests/ArrayAggregationTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/ArrayAggregationTest.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/arrayAggregationRules.json",
-        "spring.data.mongodb.database: ArrayAggregationTest",
+        "spring.mongodb.database: ArrayAggregationTest",
         "failed.notifications.collection.name: ArrayAggregationTest-failedNotifications",
         "rabbitmq.exchange.name: ArrayAggregationTest-exchange",
         "rabbitmq.queue.suffix: ArrayAggregationTest" })

--- a/src/test/java/com/ericsson/ei/flowtests/FlowSourceChangeObject.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowSourceChangeObject.java
@@ -56,7 +56,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/SourceChangeObjectRules.json",
-        "spring.data.mongodb.database: FlowSourceChangeObject",
+        "spring.mongodb.database: FlowSourceChangeObject",
         "failed.notifications.collection.name: FlowSourceChangeObject-failedNotifications",
         "rabbitmq.exchange.name: FlowSourceChangeObject-exchange",
         "rabbitmq.queue.suffix: FlowSourceChangeObject" })

--- a/src/test/java/com/ericsson/ei/flowtests/FlowTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowTest.java
@@ -62,7 +62,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/ArtifactRules.json",
-        "spring.data.mongodb.database: FlowTest",
+        "spring.mongodb.database: FlowTest",
         "failed.notifications.collection.name: FlowTest-failedNotifications",
         "rabbitmq.exchange.name: FlowTest-exchange",
         "rabbitmq.queue.suffix: FlowTest" })

--- a/src/test/java/com/ericsson/ei/flowtests/FlowTest2.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowTest2.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/ArtifactRules.json",
-        "spring.data.mongodb.database: FlowTest2",
+        "spring.mongodb.database: FlowTest2",
         "failed.notifications.collection.name: FlowTest2-failedNotifications",
         "rabbitmq.exchange.name: FlowTest2-exchange",
         "rabbitmq.queue.suffix: FlowTest2" })

--- a/src/test/java/com/ericsson/ei/flowtests/FlowTestBase.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowTestBase.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
@@ -69,10 +69,10 @@ public abstract class FlowTestBase extends AbstractTestExecutionListener {
     @Autowired
     private WaitListStorageHandler waitlist;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
-    @Value("${spring.data.mongodb.uri}")
+    @Value("${spring.mongodb.uri}")
     private String mongoUri;
 
     @Value("${event.object.map.collection.name}")
@@ -107,7 +107,7 @@ public abstract class FlowTestBase extends AbstractTestExecutionListener {
     }
 
     private void cleanFlowTestConfigs() {
-        String dbName = System.getProperty("spring.data.mongodb.database");
+        String dbName = System.getProperty("spring.mongodb.database");
     }
 
     // setFirstEventWaitTime: variable to set the wait time after publishing the

--- a/src/test/java/com/ericsson/ei/flowtests/FlowTestTestExecution.java
+++ b/src/test/java/com/ericsson/ei/flowtests/FlowTestTestExecution.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/TestExecutionObjectRules.json",
-        "spring.data.mongodb.database: FlowTestTestExecution",
+        "spring.mongodb.database: FlowTestTestExecution",
         "failed.notifications.collection.name: FlowTestTestExecution-failedNotifications",
         "rabbitmq.exchange.name: FlowTestTestExecution-exchange",
         "rabbitmq.queue.suffix: FlowTestTestExecution" })

--- a/src/test/java/com/ericsson/ei/flowtests/SingleEventAggregationTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/SingleEventAggregationTest.java
@@ -67,7 +67,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/all_event_rules.json",
-        "spring.data.mongodb.database: SingleEventAggregationTest",
+        "spring.mongodb.database: SingleEventAggregationTest",
         "failed.notifications.collection.name: SingleEventAggregationTest-failedNotifications",
         "rabbitmq.exchange.name: SingleEventAggregationTest-exchange",
         "rabbitmq.queue.suffix: SingleEventAggregationTest" })

--- a/src/test/java/com/ericsson/ei/flowtests/TrafficGeneratedTest.java
+++ b/src/test/java/com/ericsson/ei/flowtests/TrafficGeneratedTest.java
@@ -72,7 +72,7 @@ import com.rabbitmq.client.Channel;
 @SpringBootTest(classes = App.class)
 @TestPropertySource(properties = {
         "rules.path: src/test/resources/ArtifactRules.json",
-        "spring.data.mongodb.database: TrafficGeneratedTest",
+        "spring.mongodb.database: TrafficGeneratedTest",
         "failed.notifications.collection.name: TrafficGeneratedTest-failedNotifications",
         "rabbitmq.exchange.name: TrafficGeneratedTest-exchange",
         "rabbitmq.queue.suffix: TrafficGeneratedTest"  })
@@ -99,7 +99,7 @@ public class TrafficGeneratedTest extends FlowTestBase {
     @Mock
     private ERQueryService erQueryService;
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
     @Value("${event.object.map.collection.name}")
     private String event_map;

--- a/src/test/java/com/ericsson/ei/handlers/test/UpStreamEventHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/handlers/test/UpStreamEventHandlerTest.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: UpStreamEventHandlerTest",
+        "spring.mongodb.database: UpStreamEventHandlerTest",
         "failed.notifications.collection.name: UpStreamEventHandlerTest-failedNotifications",
         "rabbitmq.exchange.name: UpStreamEventHandlerTest-exchange",
         "rabbitmq.queue.suffix: UpStreamEventHandlerTest",

--- a/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/EmailSenderTest.java
@@ -15,7 +15,7 @@ package com.ericsson.ei.notifications;
 
 import static org.mockito.Mockito.doThrow;
 
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/ericsson/ei/notifications/HttpRequestTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/HttpRequestTest.java
@@ -46,7 +46,7 @@ import com.mongodb.client.MongoCursor;
 import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: HttpRequestTest",
+        "spring.mongodb.database: HttpRequestTest",
         "failed.notifications.collection.name: HttpRequestTest-failedNotifications",
         "rabbitmq.exchange.name: HttpRequestTest-exchange",
         "rabbitmq.queue.suffix: HttpRequestTest" })
@@ -85,7 +85,7 @@ public class HttpRequestTest {
         ListDatabasesIterable<Document> list = mongoClient.listDatabases();
         MongoCursor<Document> iter = list.iterator(); 
         String port = "" + iter.getServerAddress().getPort();
-        System.setProperty("spring.data.mongodb.port", port);
+        System.setProperty("spring.mongodb.port", port);
     }
 
     @BeforeClass
@@ -95,6 +95,7 @@ public class HttpRequestTest {
 
     @Before
     public void beforeTests() throws IOException {
+        org.mockito.MockitoAnnotations.openMocks(this);
         subscription = new RestPostSubscriptionObject("My_subscription_name");
         subscription.setAuthenticationType("BASIC_AUTH_JENKINS_CSRF")
                     .setUsername(USERNAME)

--- a/src/test/java/com/ericsson/ei/notifications/InformSubscriberTest.java
+++ b/src/test/java/com/ericsson/ei/notifications/InformSubscriberTest.java
@@ -25,7 +25,7 @@ import static org.powermock.reflect.Whitebox.invokeMethod;
 import java.io.File;
 import java.io.IOException;
 
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;

--- a/src/test/java/com/ericsson/ei/queryservice/test/QueryServiceRESTAPITest.java
+++ b/src/test/java/com/ericsson/ei/queryservice/test/QueryServiceRESTAPITest.java
@@ -19,7 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.io.FileUtils;
 import org.json.JSONArray;
@@ -31,9 +31,10 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootContextLoader;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -46,6 +47,7 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.ericsson.ei.App;
+import com.ericsson.ei.EndpointSecurity;
 import com.ericsson.ei.controller.AggregatedObjectController;
 import com.ericsson.ei.controller.AggregatedObjectControllerImpl;
 import com.ericsson.ei.controller.EntryPointConstantsUtils;
@@ -56,19 +58,20 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: QueryServiceRESTAPITest",
+        "spring.mongodb.database: QueryServiceRESTAPITest",
         "failed.notifications.collection.name: QueryServiceRESTAPITest-failedNotifications",
         "rabbitmq.exchange.name: QueryServiceRESTAPITest-exchange",
         "rabbitmq.queue.suffix: QueryServiceRESTAPITest" })
 @ContextConfiguration(classes = App.class, loader = SpringBootContextLoader.class, initializers = TestContextInitializer.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebMvcTest(value = AggregatedObjectController.class)
+@Import(EndpointSecurity.class)
 public class QueryServiceRESTAPITest {
 
     @Autowired
     private MockMvc mockMvc;
     
-    @MockBean
+    @MockitoBean
     private Encryptor encryptor;
 
     static JSONArray jsonArray = null;
@@ -84,10 +87,10 @@ public class QueryServiceRESTAPITest {
 
     ObjectMapper mapper = new ObjectMapper();
 
-    @MockBean
+    @MockitoBean
     private AggregatedObjectControllerImpl aggregatedObjectController;
 
-    @MockBean
+    @MockitoBean
     private FailedNotificationControllerImpl failedNotificationController;
 
     @BeforeClass

--- a/src/test/java/com/ericsson/ei/queryservice/test/QueryServiceTest.java
+++ b/src/test/java/com/ericsson/ei/queryservice/test/QueryServiceTest.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FileUtils;
 import org.bson.BsonDocument;
@@ -52,7 +52,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoClient;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: QueryServiceTest",
+        "spring.mongodb.database: QueryServiceTest",
         "failed.notifications.collection.name: QueryServiceRESTAPITest-failedNotifications",
         "rabbitmq.exchange.name: QueryServiceTest-exchange",
         "rabbitmq.queue.suffix: QueryServiceTest"})
@@ -63,7 +63,7 @@ public class QueryServiceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(QueryServiceTest.class);
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String database;
 
     @Value("${aggregations.collection.name}")

--- a/src/test/java/com/ericsson/ei/queryservice/test/TestProcessQueryParams.java
+++ b/src/test/java/com/ericsson/ei/queryservice/test/TestProcessQueryParams.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -35,7 +35,7 @@ import com.ericsson.ei.queryservice.ProcessQueryParams;
 import com.ericsson.ei.utils.TestContextInitializer;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestProcessQueryParams",
+        "spring.mongodb.database: TestProcessQueryParams",
         "failed.notifications.collection.name: QueryServiceRESTAPITest-failedNotifications",
         "rabbitmq.exchange.name: TestProcessQueryParams-exchange",
         "rabbitmq.queue.suffix: TestProcessQueryParams" })
@@ -56,10 +56,10 @@ public class TestProcessQueryParams {
     @Autowired
     private ProcessQueryParams processQueryParams;
 
-    @MockBean
+    @MockitoBean
     private ProcessAggregatedObject processAggregatedObject;
     
-    @MockBean
+    @MockitoBean
     private Encryptor encryptor;
 
     @BeforeClass

--- a/src/test/java/com/ericsson/ei/rules/MatchIdRulesHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/rules/MatchIdRulesHandlerTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
-import org.powermock.reflect.Whitebox;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.ericsson.ei.exception.ReplacementMarkerException;
 import com.ericsson.ei.rules.RulesObject;
@@ -68,12 +68,12 @@ public class MatchIdRulesHandlerTest {
 
     private void setMatchingProperty() {
         matchIdRulesHandler = new MatchIdRulesHandler();
-        Whitebox.setInternalState(matchIdRulesHandler, "replacementMarker",
+        ReflectionTestUtils.setField(matchIdRulesHandler, "replacementMarker",
                 "%IdentifyRulesEventId%");
     }
 
     private void setMismatchingProperty() {
         matchIdRulesHandler = new MatchIdRulesHandler();
-        Whitebox.setInternalState(matchIdRulesHandler, "replacementMarker", "%IdentifyRulesEvent%");
+        ReflectionTestUtils.setField(matchIdRulesHandler, "replacementMarker", "%IdentifyRulesEvent%");
     }
 }

--- a/src/test/java/com/ericsson/ei/rules/TestRulesRestAPI.java
+++ b/src/test/java/com/ericsson/ei/rules/TestRulesRestAPI.java
@@ -32,10 +32,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -52,7 +52,7 @@ import com.ericsson.ei.controller.RuleTestControllerImpl;
 import com.ericsson.ei.utils.TestContextInitializer;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestRulesRestAPI",
+        "spring.mongodb.database: TestRulesRestAPI",
         "failed.notifications.collection.name: TestRulesService-missedNotifications",
         "rabbitmq.exchange.name: TestRulesRestAPI-exchange",
         "rabbitmq.queue.suffix: TestRulesRestAPI" })
@@ -71,7 +71,7 @@ public class TestRulesRestAPI {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private IRuleTestService ruleTestService;
 
     @Value("${test.aggregation.enabled:false}")

--- a/src/test/java/com/ericsson/ei/rules/TestRulesService.java
+++ b/src/test/java/com/ericsson/ei/rules/TestRulesService.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import com.ericsson.ei.exception.InvalidRulesException;
 import org.apache.commons.io.FileUtils;
@@ -26,7 +26,7 @@ import com.ericsson.ei.utils.TestContextInitializer;
 import com.mongodb.client.MongoClient;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: TestRulesService",
+        "spring.mongodb.database: TestRulesService",
         "failed.notifications.collection.name: TestRulesService-missedNotifications",
         "rabbitmq.exchange.name: TestRulesService-exchange",
         "rabbitmq.queue.suffix: TestRulesService" })

--- a/src/test/java/com/ericsson/ei/services/SubscriptionRestAPITest.java
+++ b/src/test/java/com/ericsson/ei/services/SubscriptionRestAPITest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -49,8 +49,11 @@ import com.ericsson.ei.encryption.Encryptor;
 import com.ericsson.ei.exception.SubscriptionNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.ericsson.ei.EndpointSecurity;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebMvcTest(value = SubscriptionController.class)
+@org.springframework.context.annotation.Import(EndpointSecurity.class)
 public class SubscriptionRestAPITest {
 
     private static final String SUBSCRIPTION = "src/test/resources/subscription_single.json";
@@ -62,15 +65,15 @@ public class SubscriptionRestAPITest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private ISubscriptionService subscriptionService;
 
-    @MockBean
+    @MockitoBean
     private Authentication authentication;
 
-    @MockBean
+    @MockitoBean
     private SecurityContext securityContext;
-	@MockBean private Encryptor encryptor;
+	@MockitoBean private Encryptor encryptor;
 	
 
     private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/com/ericsson/ei/services/SubscriptionServiceTest.java
+++ b/src/test/java/com/ericsson/ei/services/SubscriptionServiceTest.java
@@ -42,7 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.expression.AccessException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -51,7 +51,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -65,7 +65,7 @@ import java.util.Scanner;
 import static org.junit.Assert.*;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionServiceTest",
+        "spring.mongodb.database: SubscriptionServiceTest",
         "failed.notifications.collection.name: SubscriptionServiceTest-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionServiceTest-exchange",
         "rabbitmq.queue.suffix: SubscriptionServiceTest" })
@@ -79,7 +79,7 @@ public class SubscriptionServiceTest {
     private static final String subscriptionJsonPath = "src/test/resources/subscription_CLME.json";
     private static final String subscriptionJsonPath_du = "src/test/resources/subscription_single_differentUser.json";
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String dataBaseName;
 
     @Value("${subscriptions.repeat.handler.collection.name}")
@@ -96,9 +96,9 @@ public class SubscriptionServiceTest {
     @Autowired
     private MongoDBHandler mongoDBHandler;
 
-    @MockBean
+    @MockitoBean
     private Authentication authentication;
-    @MockBean
+    @MockitoBean
     private SecurityContext securityContext;
 
     private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/com/ericsson/ei/subscription/RunSubscriptionTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/RunSubscriptionTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootContextLoader;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionHandlerTest",
+        "spring.mongodb.database: SubscriptionHandlerTest",
         "failed.notifications.collection.name: SubscriptionHandlerTest-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionHandlerTest-exchange",
         "subscriptions.repeat.handler.collection.name: SubscriptionHandlerTestCollection",
@@ -77,7 +77,7 @@ public class RunSubscriptionTest {
     private static String subscriptionRepeatFlagTrueData;
 
 
-    @Value("${spring.data.mongodb.database}")
+    @Value("${spring.mongodb.database}")
     private String subRepeatFlagDataBaseName;
 
     @Value("${subscriptions.repeat.handler.collection.name}")

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionRepeatDbHandlerTest.java
@@ -18,7 +18,7 @@ package com.ericsson.ei.subscription;
 
 import static org.junit.Assert.assertEquals;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +35,7 @@ import com.ericsson.ei.utils.FunctionalTestBase;
 import com.mongodb.BasicDBObject;
 
 @TestPropertySource(properties = {
-        "spring.data.mongodb.database: SubscriptionRepeatDbHandlerTest",
+        "spring.mongodb.database: SubscriptionRepeatDbHandlerTest",
         "failed.notifications.collection.name: SubscriptionRepeatDbHandlerTest-failedNotifications",
         "rabbitmq.exchange.name: SubscriptionRepeatDbHandlerTest-exchange",
         "rabbitmq.queue.suffix: SubscriptionRepeatDbHandlerTest" })

--- a/src/test/java/com/ericsson/ei/subscription/SubscriptionValidatorTest.java
+++ b/src/test/java/com/ericsson/ei/subscription/SubscriptionValidatorTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.fail;
 import static org.powermock.reflect.Whitebox.invokeMethod;
 
 import org.junit.Test;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -31,7 +30,6 @@ import com.ericsson.ei.controller.model.Subscription;
 import com.ericsson.ei.exception.SubscriptionValidationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@PowerMockRunnerDelegate(SpringJUnit4ClassRunner.class)
 public class SubscriptionValidatorTest {
 
     private Subscription subscriptionValid;

--- a/src/test/java/com/ericsson/ei/test/utils/TestConfigs.java
+++ b/src/test/java/com/ericsson/ei/test/utils/TestConfigs.java
@@ -12,7 +12,7 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import com.ericsson.ei.utils.AMQPBrokerManager;
 import com.mongodb.client.ListDatabasesIterable;
@@ -57,7 +57,7 @@ public class TestConfigs {
             return;
         }
 
-        int port = SocketUtils.findAvailableTcpPort();
+        int port = TestSocketUtils.findAvailableTcpPort();
         setSystemProperties(port);
         setupBroker(port);
 
@@ -133,8 +133,9 @@ public class TestConfigs {
 
     private static void setNewPortToMongoDBUriProperty(String mongoUri, String port) {
         String modifiedUri = mongoUri.replaceAll("[0-9]{4,5}", port);
-        System.setProperty("spring.data.mongodb.uri", modifiedUri);
-        LOGGER.debug("System property 'spring.data.mongodb.uri' changed from '{}' to '{}'",
+        System.setProperty("spring.mongodb.uri", modifiedUri);
+        System.setProperty("spring.mongodb.uri", modifiedUri);
+        LOGGER.debug("System property 'spring.mongodb.uri' changed from '{}' to '{}'",
                 mongoUri, modifiedUri);
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,10 +9,8 @@ logging.level.com.ericsson.ei: ERROR
 
 rules.path: /rules/ArtifactRules-Eiffel-Agen-Version.json
 rules.replacement.marker: %IdentifyRulesEventId%
-
 # WARNING! Do not enable this in a production environment!
 test.aggregation.enabled: false
-
 rabbitmq.host: localhost
 rabbitmq.port: 5672
 rabbitmq.user: myuser
@@ -25,15 +23,11 @@ rabbitmq.queue.suffix: messageQueue
 rabbitmq.queue.durable: true
 rabbitmq.binding.key: #
 rabbitmq.waitlist.queue.suffix: waitList
-
 bindingkeys.collection.name: binding_keys
-
-spring.data.mongodb.uri: mongodb://localhost:27017
-spring.data.mongodb.database: eiffel_intelligence
-
+spring.mongodb.uri: mongodb://localhost:27017
+spring.mongodb.database: eiffel_intelligence
 server.session.timeout: 1200
 sessions.collection.name: sessions
-
 aggregations.collection.name: aggregations
 aggregations.collection.ttl:
 event.object.map.collection.name: event_object_map
@@ -47,20 +41,16 @@ failed.notifications.collection.name: failed_notifications
 failed.notifications.collection.ttl: 600
 notification.retry: 3
 notification.httpRequest.timeout: 5000
-
 email.sender: noreply@domain.com
 email.subject: Email Subscription Notification
-
 spring.mail.host:
 spring.mail.port:
 spring.mail.username:
 spring.mail.password:
 spring.mail.properties.mail.smtp.auth: false
 spring.mail.properties.mail.smtp.starttls.enable: false
-
 event.repository.url: 
 event.repository.shallow: true
-
 ldap.enabled: false
 ldap.server.list: [{\
         "url": "",\
@@ -69,17 +59,13 @@ ldap.server.list: [{\
         "password": "",\
         "user.filter": ""\
     }]
-
 ### DEVELOPER SETTINGS
-
 spring.mongodb.embedded.version: 3.4.1
 # We remove the embedded mongodb in tests since in most of them we set up our own before Spring
 # starts and activate it manually in tests where we need the Spring's own embedded mongo DB
 spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
-
 threads.core.pool.size: 200
 threads.queue.capacity: 7000
 threads.max.pool.size: 250
 scheduled.threadpool.size: 200
 jasypt.encryptor.password=test
-

--- a/src/test/resources/configs/password.properties
+++ b/src/test/resources/configs/password.properties
@@ -1,1 +1,2 @@
 guest:guest
+myuser:myuser

--- a/src/test/resources/configs/qpidConfig.json
+++ b/src/test/resources/configs/qpidConfig.json
@@ -1,6 +1,6 @@
 {
   "name": "Embedded Broker",
-  "modelVersion": "7.1",
+  "modelVersion": "9.0",
   "authenticationproviders" : [ {
     "name" : "passwordFile",
     "path" : "${qpid.pass_file}",
@@ -27,6 +27,6 @@
     "name" : "default",
     "type" : "Memory",
     "defaultVirtualHostNode" : "true",
-    "virtualHostInitialConfiguration" : "{\"type\" : \"Memory\",\"name\" : \"default\",\"modelVersion\" : \"7.1\"}"
+    "virtualHostInitialConfiguration" : "{\"type\" : \"Memory\",\"name\" : \"default\",\"modelVersion\" : \"9.0\"}"
   }]
 }


### PR DESCRIPTION
### Applicable Issues

Upgrade Spring Boot from 2.7.5 to 4.0.4 for Tomcat 11 support.

### Description of the Change

- Upgrade spring-boot-starter-parent from 2.7.5 to 4.0.4
- Migrate javax.* to jakarta.* (Servlet, Validation)
- Migrate SpringFox to SpringDoc (OpenAPI 3)
- Migrate WebSecurityConfigurerAdapter to SecurityFilterChain
- Upgrade Qpid broker from 7.1.0 to 9.1.0
- Upgrade Jasypt from 2.1.2 to 3.0.5
- Replace PowerMock with powermock-reflect 2.0.9
- Rename spring.data.mongodb.* to spring.mongodb.* (SB4 property names)
- BOM-managed Spring dependency versions
- Disable RAML plugin (javax incompatible, controllers maintained manually)
- Update Docker test images (RabbitMQ, Jenkins)

### Checklist

- [x] Tests pass
- [x] Code compiles
- [x] Documentation updated