### PR TITLE
Fix X-Auth-Token missing in login response after Spring Boot 4 migration

### DIFF
--- a/src/main/java/com/ericsson/ei/EndpointSecurity.java
+++ b/src/main/java/com/ericsson/ei/EndpointSecurity.java
@@ -33,6 +33,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 import com.ericsson.ei.encryption.EncryptionUtils;
 import com.ericsson.ei.encryption.Encryptor;
@@ -74,8 +75,11 @@ public class EndpointSecurity {
                     .requestMatchers(HttpMethod.DELETE, "/subscriptions/*").authenticated()
                     .anyRequest().permitAll()
                 )
+                .securityContext(context -> context
+                    .securityContextRepository(new HttpSessionSecurityContextRepository())
+                )
                 .sessionManagement(session -> session
-                    .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                    .sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
                 )
                 .logout(logout -> logout
                     .logoutUrl("/authentication/logout")
@@ -84,6 +88,8 @@ public class EndpointSecurity {
                     .invalidateHttpSession(true)
                 )
                 .httpBasic(basic -> {})
+                .addFilterAfter(new com.ericsson.ei.config.EagerSessionFilter(),
+                    org.springframework.security.web.authentication.www.BasicAuthenticationFilter.class)
                 .csrf(csrf -> csrf.disable());
         } else {
             LOGGER.info("LDAP security configuration is disabled");

--- a/src/main/java/com/ericsson/ei/config/EagerSessionFilter.java
+++ b/src/main/java/com/ericsson/ei/config/EagerSessionFilter.java
@@ -1,0 +1,26 @@
+package com.ericsson.ei.config;
+
+import java.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Placed inside Spring Security filter chain after BasicAuthenticationFilter.
+ * Creates session and sets X-Auth-Token header BEFORE the controller writes
+ * the response body (which commits the response).
+ */
+public class EagerSessionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        // Force session creation and set header before response is committed
+        HttpSession session = request.getSession(true);
+        response.setHeader("X-Auth-Token", session.getId());
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/ericsson/ei/config/HeaderAndCookieHttpSessionIdResolver.java
+++ b/src/main/java/com/ericsson/ei/config/HeaderAndCookieHttpSessionIdResolver.java
@@ -27,7 +27,6 @@ public final class HeaderAndCookieHttpSessionIdResolver implements HttpSessionId
         } else {
             sessionIds = Collections.singletonList(headerValue);
         }
-
         return sessionIds;
     }
 

--- a/src/main/java/com/ericsson/ei/config/HttpSessionConfig.java
+++ b/src/main/java/com/ericsson/ei/config/HttpSessionConfig.java
@@ -1,15 +1,16 @@
 package com.ericsson.ei.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.session.data.mongo.MongoIndexedSessionRepository;
-import org.springframework.session.data.mongo.config.annotation.web.http.EnableMongoHttpSession;
 import org.springframework.session.web.http.HttpSessionIdResolver;
+import org.springframework.session.web.http.SessionRepositoryFilter;
 
-@EnableMongoHttpSession()
+@Configuration
 public class HttpSessionConfig {
 
     @Value("${server.session.timeout}")
@@ -18,20 +19,36 @@ public class HttpSessionConfig {
     @Value("${sessions.collection.name}")
     private String collectionName;
 
-    @Primary
     @Bean
-    public MongoIndexedSessionRepository mongoIndexedSessionRepository(MongoOperations mongoOperations) {
-    	MongoIndexedSessionRepository repository = new MongoIndexedSessionRepository(mongoOperations);
+    public MongoIndexedSessionRepository sessionRepository(MongoOperations mongoOperations) {
+        MongoIndexedSessionRepository repository = new MongoIndexedSessionRepository(mongoOperations);
         repository.setMaxInactiveIntervalInSeconds(maxInactiveIntervalInSeconds);
+        repository.setCollectionName(collectionName);
         return repository;
-    }
-
-    public static String getCurrentUser() {
-        return SecurityContextHolder.getContext().getAuthentication().getName();
     }
 
     @Bean
     public HttpSessionIdResolver httpSessionIdResolver() {
         return new HeaderAndCookieHttpSessionIdResolver();
+    }
+
+    @Bean
+    public SessionRepositoryFilter<?> springSessionRepositoryFilter(MongoIndexedSessionRepository sessionRepository) {
+        SessionRepositoryFilter<?> filter = new SessionRepositoryFilter<>(sessionRepository);
+        filter.setHttpSessionIdResolver(httpSessionIdResolver());
+        return filter;
+    }
+
+    @Bean
+    public FilterRegistrationBean<SessionRepositoryFilter<?>> sessionFilterRegistration(
+            SessionRepositoryFilter<?> springSessionRepositoryFilter) {
+        FilterRegistrationBean<SessionRepositoryFilter<?>> reg = new FilterRegistrationBean<>(springSessionRepositoryFilter);
+        reg.setName("springSessionRepositoryFilter");
+        reg.setOrder(Integer.MIN_VALUE + 50);
+        return reg;
+    }
+
+    public static String getCurrentUser() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
     }
 }


### PR DESCRIPTION
## Summary

After the Spring Boot 4 + Tomcat 11 migration, the `/authentication/login` endpoint no longer returns the `X-Auth-Token` response header. This breaks M2M authentication flow where clients rely on this token for subsequent API calls.

## Root Causes

1. **No MongoDB session auto-configuration in Spring Boot 4** — `SessionRepositoryFilter` was never registered with the servlet container
2. **Spring Security 6 removed implicit SecurityContext persistence** — sessions were created but authentication state was not saved
3. **Tomcat 11 commits response before `SessionRepositoryFilter` can set headers** — the filter sets `X-Auth-Token` in its `finally` block, which is too late

## Changes

| File | Change |
|------|--------|
| `HttpSessionConfig.java` | Replace `@EnableMongoHttpSession` with manual `SessionRepositoryFilter` + `FilterRegistrationBean` |
| `EndpointSecurity.java` | Add `HttpSessionSecurityContextRepository`, `SessionCreationPolicy.ALWAYS`, and `EagerSessionFilter` |
| `EagerSessionFilter.java` (new) | Sets `X-Auth-Token` header before response commits |
| `HeaderAndCookieHttpSessionIdResolver.java` | Minor cleanup |

## Testing

- Verified `X-Auth-Token` is returned on login response
- Verified session is persisted to MongoDB
- Verified token reuse works (subsequent requests with token are authenticated without credentials)