### PR TITLE
Remove unused jboss-public-repository-group from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,7 @@
     <!-- Repositories from additional providers -->
     <!-- WARNING: Changes made here must also be made in .mvn/project-settings.xml -->
     <repositories>
-        <repository>
-            <id>jboss-public-repository-group</id>
-            <name>JBoss Public Maven Repository Group</name>
-            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
-        </repository>
+
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>


### PR DESCRIPTION
No dependencies are resolved from jboss-public-repository-group — all come from Maven Central. The extra repo causes hundreds of failed HTTP lookups per build, pushing JitPack builds past the 20-minute timeout.

Removed from pom.xml. Kept jitpack.io repository for JitPack-hosted dependencies.